### PR TITLE
feat: search all lets client include only modified as extra field

### DIFF
--- a/course_discovery/apps/api/tests/test_serializers.py
+++ b/course_discovery/apps/api/tests/test_serializers.py
@@ -2414,7 +2414,7 @@ class CourseSearchDocumentSerializerTests(ElasticsearchTestMixin, TestCase, Cour
         if is_post_request:
             request = make_post_request({'detail_fields': True})
         else:
-            request = make_request({'detail_fields': True})
+            request = make_request({'detail_fields': 'true'})
         organization = OrganizationFactory()
         # 'organizations' in serialized data should not return duplicate organization names
         # Add the same organization twice to the course and make sure only one is in the serialized data
@@ -2510,6 +2510,18 @@ class CourseSearchDocumentSerializerTests(ElasticsearchTestMixin, TestCase, Cour
             del expected['modified']
         serializer = self.serialize_course(course, request)
         self.assertDictEqual(serializer.data, expected)
+
+    def test_include_modified_without_detail_fields(self):
+        """include_modified=true returns modified but not level_type or outcome."""
+        request = make_request({'include_modified': 'true'})
+        course = CourseFactory()
+        CourseRunFactory(course=course)
+        course.save()
+
+        data = self.serialize_course(course, request).data
+        assert 'modified' in data
+        assert 'level_type' not in data
+        assert 'outcome' not in data
 
     @classmethod
     def get_expected_data(cls, course, course_run, course_skill, seat):

--- a/course_discovery/apps/course_metadata/search_indexes/serializers/course.py
+++ b/course_discovery/apps/course_metadata/search_indexes/serializers/course.py
@@ -158,12 +158,18 @@ class CourseSearchDocumentSerializer(ModelObjectDocumentSerializerMixin, DateTim
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         request = self.context['request']
-        detail_fields = request.GET.get('detail_fields')
-        # if detail_fields query_param not in request than do not add the following fields in serializer response.
+        detail_fields = request.query_params.get('detail_fields', 'false') == 'true'
+        include_modified = request.query_params.get('include_modified', 'false') == 'true'
+
+        # if detail_fields query_param not in request, do not add the following fields in serializer response.
         if not detail_fields:
             self.fields.pop('level_type', None)
-            self.fields.pop('modified', None)
             self.fields.pop('outcome', None)
+
+        # allow the client to request only that the course modified field is included without
+        # including all the other fields dictated by detail_fields (notably, the expanded course run fiels)
+        if not include_modified and not detail_fields:
+            self.fields.pop('modified', None)
 
     def to_representation(self, instance):
         """

--- a/course_discovery/apps/course_metadata/search_indexes/serializers/course.py
+++ b/course_discovery/apps/course_metadata/search_indexes/serializers/course.py
@@ -158,12 +158,19 @@ class CourseSearchDocumentSerializer(ModelObjectDocumentSerializerMixin, DateTim
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         request = self.context['request']
-        detail_fields = request.GET.get('detail_fields')
-        # if detail_fields query_param not in request than do not add the following fields in serializer response.
+        detail_fields = request.query_params.get('detail_fields', 'false').lower() == 'true'
+        include_modified = request.query_params.get('include_modified', 'false').lower() == 'true'
+
+        # if detail_fields query_param not in request, do not add the following fields in serializer response.
         if not detail_fields:
             self.fields.pop('level_type', None)
-            self.fields.pop('modified', None)
             self.fields.pop('outcome', None)
+
+        # `include_modified` allows the client to request only that the course modified field is included
+        # in the serialized response, without also including the other fields
+        # dictated by `detail_fields` (notably, the expanded course run fields)
+        if not include_modified and not detail_fields:
+            self.fields.pop('modified', None)
 
     def to_representation(self, instance):
         """


### PR DESCRIPTION
https://2u-internal.atlassian.net/browse/ENT-11976

Enables clients of the `search/all` endpoint to access the `modified` value of records without the additional serialization latency introduced by the presences of the `detail_fields` query param (which expands a somewhat expensive serializer inside the nested course runs of the course serializer)