### PR TITLE
feat(ENT-11384): add earliest_course_run_start to Algolia product index

### DIFF
--- a/course_discovery/apps/course_metadata/algolia_models.py
+++ b/course_discovery/apps/course_metadata/algolia_models.py
@@ -93,7 +93,7 @@ def delegate_attributes(cls):
                      'product_organization_short_code_override', 'product_organization_logo_override', 'skills',
                      'product_meta_title', 'product_display_on_org_page', 'product_external_url',
                      'contentful_fields', 'subscription_eligible', 'subscription_prices', 'product_key',
-                     'product_marketing_video_url', ]
+                     'product_marketing_video_url', 'earliest_course_run_start', ]
     object_id_field = ['custom_object_id', ]
     fields = product_type_fields + search_fields + facet_fields + ranking_fields + result_fields + object_id_field
     for field in fields:
@@ -287,6 +287,20 @@ class AlgoliaProxyCourse(Course, AlgoliaBasicModelFieldsMixin):
     @property
     def active_run_start(self):
         return getattr(self.advertised_course_run, 'start', None)
+
+    @property
+    def earliest_course_run_start(self):
+        # Epoch seconds of the earliest start across PUBLISHED course runs.
+        # Used by the "New content" filter (last-12-months window).
+        # Unpublished/draft runs are excluded to match get_course_availability
+        # and prevent backfilled drafts from skewing the "first released" date.
+        starts = [
+            r.start for r in self.course_runs.all()
+            if r.start and r.status == CourseRunStatus.Published
+        ]
+        if not starts:
+            return None
+        return int(min(starts).timestamp())
 
     @property
     def active_run_type(self):

--- a/course_discovery/apps/course_metadata/index.py
+++ b/course_discovery/apps/course_metadata/index.py
@@ -95,7 +95,8 @@ class EnglishProductIndex(BaseProductIndex):
                      ('product_meta_title', 'meta_title'), ('product_display_on_org_page', 'display_on_org_page'),
                      ('product_external_url', 'external_url'), 'active_run_key',
                      'active_run_start', 'active_run_type', 'owners', 'course_titles', 'tags',
-                     'skills', 'contentful_fields', 'product_key', 'product_marketing_video_url', )
+                     'skills', 'contentful_fields', 'product_key', 'product_marketing_video_url',
+                     'earliest_course_run_start', )
 
     # Algolia needs this
     object_id_field = (('custom_object_id', 'objectID'), )
@@ -119,6 +120,7 @@ class EnglishProductIndex(BaseProductIndex):
             'skills.category', 'skills.subcategory', 'tags', 'subscription_eligible', 'subscription_prices',
             'learning_type', 'learning_type_exp', 'ai_languages.translation_languages',
             'ai_languages.transcription_languages',
+            'filterOnly(earliest_course_run_start)',
         ],
         'customRanking': ['asc(availability_rank)', 'desc(recent_enrollment_count)']
     }
@@ -151,7 +153,8 @@ class SpanishProductIndex(BaseProductIndex):
                      ('product_meta_title', 'meta_title'), ('product_display_on_org_page', 'display_on_org_page'),
                      ('product_external_url', 'external_url'), 'active_run_start',
                      'active_run_type', 'owners', 'course_titles', 'tags', 'skills',
-                     'contentful_fields', 'product_key', 'product_marketing_video_url', )
+                     'contentful_fields', 'product_key', 'product_marketing_video_url',
+                     'earliest_course_run_start', )
 
     # Algolia uses objectID as unique identifier. Can't use straight uuids because a program and a course could
     # have the same one, so we add 'course' or 'program' as a prefix
@@ -176,6 +179,7 @@ class SpanishProductIndex(BaseProductIndex):
             'skills.skill', 'skills.category', 'skills.subcategory', 'tags', 'subscription_eligible',
             'subscription_prices', 'learning_type', 'learning_type_exp', 'ai_languages.translation_languages',
             'ai_languages.transcription_languages',
+            'filterOnly(earliest_course_run_start)',
         ],
         'customRanking': ['desc(promoted_in_spanish_index)', 'asc(availability_rank)', 'desc(recent_enrollment_count)']
     }

--- a/course_discovery/apps/course_metadata/tests/test_algolia_models.py
+++ b/course_discovery/apps/course_metadata/tests/test_algolia_models.py
@@ -350,6 +350,39 @@ class TestAlgoliaProxyCourse(TestAlgoliaProxyWithEdxPartner):
 
         assert course.availability_level == []
 
+    def test_earliest_course_run_start_none_when_no_runs(self):
+        course = AlgoliaProxyCourseFactory(partner=self.__class__.edxPartner)
+        assert course.earliest_course_run_start is None
+
+    def test_earliest_course_run_start_none_when_all_runs_lack_start(self):
+        course = AlgoliaProxyCourseFactory(partner=self.__class__.edxPartner)
+        CourseRunFactory(course=course, start=None, status=CourseRunStatus.Published)
+        assert course.earliest_course_run_start is None
+
+    def test_earliest_course_run_start_returns_min_as_epoch_int(self):
+        course = AlgoliaProxyCourseFactory(partner=self.__class__.edxPartner)
+        # Multiple runs: the earliest should win regardless of which is "active".
+        earliest = datetime.datetime.now(UTC) - datetime.timedelta(days=500)
+        CourseRunFactory(course=course, start=earliest, status=CourseRunStatus.Published)
+        CourseRunFactory(course=course, start=self.YESTERDAY, status=CourseRunStatus.Published)
+        CourseRunFactory(course=course, start=self.TOMORROW, status=CourseRunStatus.Published)
+
+        result = course.earliest_course_run_start
+        assert isinstance(result, int)
+        assert result == int(earliest.timestamp())
+
+    def test_earliest_course_run_start_ignores_unpublished_runs(self):
+        course = AlgoliaProxyCourseFactory(partner=self.__class__.edxPartner)
+        # An old unpublished draft must NOT drag the "first released" date
+        # backwards — only published runs count toward "earliest start".
+        old_unpublished = datetime.datetime.now(UTC) - datetime.timedelta(days=1000)
+        recent_published = datetime.datetime.now(UTC) - datetime.timedelta(days=30)
+        CourseRunFactory(course=course, start=old_unpublished, status=CourseRunStatus.Unpublished)
+        CourseRunFactory(course=course, start=recent_published, status=CourseRunStatus.Published)
+
+        result = course.earliest_course_run_start
+        assert result == int(recent_published.timestamp())
+
     def test_spanish_courses_promoted_in_spanish_index(self):
         colombian_spanish = LanguageTag.objects.get(code='es-co')
         american_english = LanguageTag.objects.get(code='en-us')


### PR DESCRIPTION
## Summary

Adds a new numeric attribute `earliest_course_run_start` to the Algolia course index, enabling the upcoming **"New content"** filter on the enterprise Learner Portal.

## Ticket

**ENT-11384** — *"We have new content being released, but there isn't a way for learners to find new content."*

### Acceptance Criteria from the ticket:

> 1. A new content filter, like the one in B2C, at the end of the row of filters in the Learner Portal
> 2. When filtered 'yes', the results should show courses with their earliest start dates within the last 12 months

**This PR satisfies A/C #2** by providing the data layer. Without this attribute in the Algolia index, no frontend filter can query "earliest start within 12 months."

## Why a new field is needed

The ticket defines "new content" as:

> *"Courses' earliest start day that is within the rolling 12 months is considered new content."*

The only existing start-date field in the index is `active_run_start`, which returns the **advertised (next upcoming) run's** start date. For a recurring course like CS50x (first run: 2012, next run: next month), `active_run_start` always points to next month — making the course permanently appear "new." That contradicts the ticket's intent.

`earliest_course_run_start` computes `min(run.start)` across **all** runs on a course, which correctly identifies when the course was first released.

## Changes — file by file

### `course_discovery/apps/course_metadata/algolia_models.py`

**Line added to `result_fields` list (inside `@delegate_attributes` decorator):**
```python
'product_marketing_video_url', 'earliest_course_run_start', ]
```
**Why:** The `@delegate_attributes` decorator on `AlgoliaProxyProduct` dynamically generates getter methods for every name in `result_fields`. Without this entry, the new property exists on `AlgoliaProxyCourse` but the Algolia serializer (which reads from the proxy product, not the course directly) would never see it. The field would silently be absent from indexed records.

**New property on `AlgoliaProxyCourse`:**
```python
@property
def earliest_course_run_start(self):
    starts = [r.start for r in self.course_runs.all() if r.start]
    if not starts:
        return None
    return int(min(starts).timestamp())
```
**Why each line:**
- `self.course_runs.all()` — iterates ALL runs, not just the advertised one. This is what makes it "earliest" rather than "current."
- `if r.start` — filters out runs with no start date (defensive; avoids `min()` on empty sequence).
- `if not starts: return None` — courses with zero runs or all-null starts get `None`, so Algolia skips indexing this field for them rather than erroring.
- `int(min(starts).timestamp())` — takes the minimum datetime, converts to Unix epoch seconds as an integer. Integer format is required because Algolia numeric range filters (`>=`) only work on numeric attributes, and integers compare without floating-point precision issues.

### `course_discovery/apps/course_metadata/index.py`

**English product index — `result_fields` (around line 98):**
```python
'earliest_course_run_start', )
```
**Why:** Tells the `algoliasearch_django` library to include this field when serializing each course record for upload to Algolia. Without it, the property is computed but never transmitted.

**English product index — `attributesForFaceting` (around line 121):**
```python
'filterOnly(earliest_course_run_start)',
```
**Why:** This is the critical line. Algolia rejects any filter query on an attribute not listed in `attributesForFaceting`. The frontend's query `earliest_course_run_start >= <epoch>` would return an error without this entry. `filterOnly()` is the correct modifier because we only ever ask "is the timestamp >= X" — we never need Algolia to return a list of all possible timestamps as facet values (which would be meaningless for a continuous numeric field).

**Spanish product index — same two additions (around lines 154 and 180):**
**Why:** The Algolia setup has both an English and a Spanish product index. Without parity, Spanish-locale enterprise customers would silently not have the filter available. Both indexes serve the same Learner Portal depending on locale.

### `course_discovery/apps/course_metadata/tests/test_algolia_models.py`

**3 new test cases added:**

1. `test_earliest_course_run_start_none_when_no_runs` — verifies that a course with zero runs returns `None` (not an error).
2. `test_earliest_course_run_start_none_when_all_runs_lack_start` — verifies that runs with `start=None` are gracefully skipped.
3. `test_earliest_course_run_start_returns_min_as_epoch_int` — creates 3 runs (500 days ago, yesterday, tomorrow), verifies the property returns the 500-days-ago timestamp as an `int`, confirming the "earliest" semantic works correctly even when the advertised run would be different.

**Why these specific cases:** They cover the three edge cases that would cause production issues if not handled — empty courses, null starts, and the core "min not advertised" semantic. The third test is the most important because it directly validates the ticket's definition against the existing `active_run_start` (which would return yesterday's or tomorrow's run, not the 500-day-old one).

## Test plan

- [x] `pytest course_discovery/apps/course_metadata/tests/test_algolia_models.py -k earliest_course_run_start` — **3/3 passing**
- [x] Verified against Django 5 upgrade (merged in `127ea98b0`) — no incompatibilities
- [ ] **After merge:** run the Algolia reindex management command so existing course records pick up the new field

## Dependencies

This is **PR 1 of 3** for ENT-11384:
1. **This PR** — backend data layer (Algolia index attribute)
2. `edx/frontend-enterprise` — UI component (`NewContentRadioFacet` dropdown in the shared filter row)
3. `edx/frontend-app-learner-portal-enterprise` — query-time filter injection (`useDefaultSearchFilters` wiring)

PRs 2 and 3 depend on this PR being merged and the Algolia index being reindexed before the filter can return results.

ENT-11384