### PR TITLE
fix: prevent 'null' display when instructor family_name is missing

### DIFF
--- a/course_discovery/apps/course_metadata/people.py
+++ b/course_discovery/apps/course_metadata/people.py
@@ -19,9 +19,19 @@ class MarketingSitePeople:
         )
 
     def _get_node_data(self, person):
+        # Build name safely ignoring empty values
+        name_parts = [
+            part for part in [person.given_name, person.family_name]
+            if part
+        ]
+        full_name = " ".join(name_parts)
+        # Add salutation only when a name exists
+        if full_name and person.salutation:
+            full_name = f"{person.salutation} {full_name}"
+
         return {
             'field_person_slug': person.slug,
-            'title': person.full_name,
+            'title': full_name.strip(),
             'type': 'person',
             'status': 1 if person.published else 0
         }

--- a/course_discovery/apps/course_metadata/tests/test_people.py
+++ b/course_discovery/apps/course_metadata/tests/test_people.py
@@ -148,6 +148,57 @@ class MarketingSitePublisherTests(MarketingSitePublisherTestMixin):
         })
         self.assertDictEqual(data, expected)
 
+    def test_person_without_family_name(self):
+        person = PersonFactory(
+            partner=self.partner,
+            given_name='User',
+            family_name=None
+        )
+
+        people = MarketingSitePeople()
+        data = people._get_node_data(person)  # pylint: disable=protected-access
+
+        assert data['title'] == 'User'
+
+    def test_person_without_family_name_with_salutation(self):
+        person = PersonFactory(
+            partner=self.partner,
+            salutation='Dr.',
+            given_name='User',
+            family_name=None
+        )
+
+        people = MarketingSitePeople()
+        data = people._get_node_data(person)  # pylint: disable=protected-access
+
+        assert data['title'] == 'Dr. User'
+
+    def test_person_with_salutation_and_full_name(self):
+        person = PersonFactory(
+            partner=self.partner,
+            salutation='Dr.',
+            given_name='User',
+            family_name='Smith'
+        )
+
+        people = MarketingSitePeople()
+        data = people._get_node_data(person)  # pylint: disable=protected-access
+
+        assert data['title'] == 'Dr. User Smith'
+
+    def test_person_with_only_salutation(self):
+        person = PersonFactory(
+            partner=self.partner,
+            salutation='Dr.',
+            given_name='',
+            family_name=''
+        )
+
+        people = MarketingSitePeople()
+        data = people._get_node_data(person)  # pylint: disable=protected-access
+
+        assert data['title'] == ''
+
     @responses.activate
     def test_person_create_failed(self):
         self.mock_api_client(200)


### PR DESCRIPTION
Issue
Instructor profiles display "null" when family_name is missing.

2U Ticket
https://2u-internal.atlassian.net/browse/CATALOG-87

Root Cause
The marketing site integration was using full_name directly, which could include null values.

Fix
Updated name construction in MarketingSitePeople to safely handle missing family_name
Ensured only valid name parts are included
Added test coverage for missing and empty family_name cases
Testing
Verified profiles with and without family_name
Confirmed no "null" appears in marketing site payload