### PR TITLE
fix: add newlines preventing es-419 .po file from passing automated validation

### DIFF
--- a/course_discovery/conf/locale/es_419/LC_MESSAGES/django.po
+++ b/course_discovery/conf/locale/es_419/LC_MESSAGES/django.po
@@ -2020,7 +2020,7 @@ msgstr "\n        edX revisó de manera existosa el curso '%(course_name)s' y ya
 msgid ""
 "\n"
 "    Course '%(course_name)s' has been successfully reviewed by edX and is now published on %(course_publish_date)s. To see live course, go here: %(course_marketing_url)s\n"
-msgstr "El curso &#39; <span class='notranslate'>%(course_name)s</span> &#39; ha sido revisado con éxito por edX y ahora está publicado en <span class='notranslate'>%(course_publish_date)s</span> . Para ver el curso en vivo, vaya aquí: <span class='notranslate'>%(course_marketing_url)s</span>"
+msgstr "\n    El curso &#39; <span class='notranslate'>%(course_name)s</span> &#39; ha sido revisado con éxito por edX y ahora está publicado en <span class='notranslate'>%(course_publish_date)s</span> . Para ver el curso en vivo, vaya aquí: <span class='notranslate'>%(course_marketing_url)s</span>\n"
 
 #: apps/course_metadata/templates/course_metadata/email/watchers_course_url.txt:8
 #, python-format


### PR DESCRIPTION
For an unknown (to me) reason, course-discovery still has its translations stored locally, and the es-419 .po file it has locally had an error; one translated string was missing two expected starting and ending newlines.

For another unknown (to me) reason, course-discovery's `extract_translations` make target also runs a translation compile step. This fails on the incorrect es-419 translation.

This PR adds the expected newlines back so the compile job can pass. The compile job is not needed and we don't care about it's outputs, but we need it to not fail.

