### PR TITLE
[ENT-11386] Bump taxonomy-connector to 3.0.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -583,7 +583,7 @@ stevedore==5.7.0
     #   code-annotations
     #   edx-django-utils
     #   edx-opaque-keys
-taxonomy-connector==2.4.0
+taxonomy-connector==3.0.0
     # via -r requirements/base.in
 text-unidecode==1.3
     # via python-slugify

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -1053,7 +1053,7 @@ stevedore==5.7.0
     #   code-annotations
     #   edx-django-utils
     #   edx-opaque-keys
-taxonomy-connector==2.4.0
+taxonomy-connector==3.0.0
     # via -r requirements/test.txt
 testfixtures==11.0.0
     # via -r requirements/test.txt

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -731,7 +731,7 @@ stevedore==5.7.0
     #   code-annotations
     #   edx-django-utils
     #   edx-opaque-keys
-taxonomy-connector==2.4.0
+taxonomy-connector==3.0.0
     # via -r requirements/base.txt
 text-unidecode==1.3
     # via

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -892,7 +892,7 @@ stevedore==5.7.0
     #   code-annotations
     #   edx-django-utils
     #   edx-opaque-keys
-taxonomy-connector==2.4.0
+taxonomy-connector==3.0.0
     # via -r requirements/base.txt
 testfixtures==11.0.0
     # via -r requirements/test.in


### PR DESCRIPTION
## Summary
This PR updates the taxonomy connector to `3.0.0` and implements Spanish (with extensible multi-language support) localization for the Algolia jobs index.

This enables localized job discovery (starting with Spanish) while preserving current English behavior and minimizing operational risk during indexing.

## Ticket
- https://2u-internal.atlassian.net/browse/ENT-11386
