### PR TITLE
feat: support staff UUIDs in bulk course creation and updates

### DIFF
--- a/course_discovery/apps/course_metadata/data_loaders/course_loader.py
+++ b/course_discovery/apps/course_metadata/data_loaders/course_loader.py
@@ -15,7 +15,7 @@ from course_discovery.apps.course_metadata.data_loaders.constants import (
 )
 from course_discovery.apps.course_metadata.data_loaders.mixins import DataLoaderMixin
 from course_discovery.apps.course_metadata.data_loaders.utils import prune_empty_values
-from course_discovery.apps.course_metadata.models import Course, CourseRun, CourseRunType
+from course_discovery.apps.course_metadata.models import Course, CourseRun, CourseRunType, Person
 from course_discovery.apps.course_metadata.utils import download_and_save_course_image
 
 logger = logging.getLogger(__name__)
@@ -227,6 +227,7 @@ class CourseLoader(AbstractDataLoader, DataLoaderMixin):
             return None
 
         program_type = course_run_data.get('expected_program_type')
+        staff_uuids = self.process_staff_uuids(course_run_data.get('staff', ''))
         content_language = self.verify_and_get_language_tags(course_run_data.get('content_language') or 'en-us')
         transcript_language = self.verify_and_get_language_tags(course_run_data.get('transcript_languages') or 'en-us')
 
@@ -238,6 +239,7 @@ class CourseLoader(AbstractDataLoader, DataLoaderMixin):
             'prices': self.get_pricing_representation(
                 course_run_data.get('verified_price'), course_type or course_run.course.type
             ),
+            'staff': staff_uuids,
             'draft': is_draft,
             'content_language': content_language[0],
             'expected_program_name': course_run_data.get('expected_program_name', ''),
@@ -272,6 +274,28 @@ class CourseLoader(AbstractDataLoader, DataLoaderMixin):
             prune_empty_values(update_course_run_data)
 
         return update_course_run_data
+
+    def process_staff_uuids(self, staff_data):
+        """
+        Validate and normalize comma-separated staff UUIDs from csv.
+        """
+        if not staff_data:
+            return []
+
+        seen = set()
+        valid_staff_uuids = []
+        for staff_uuid in [value.strip() for value in staff_data.split(',') if value.strip()]:
+            if staff_uuid in seen:
+                continue
+
+            person = Person.objects.filter(uuid=staff_uuid, partner=self.partner).first()
+            if not person:
+                raise Exception(f"Instructor with UUID {staff_uuid} not found")
+
+            seen.add(staff_uuid)
+            valid_staff_uuids.append(str(person.uuid))
+
+        return valid_staff_uuids
 
     def download_course_image_assets(self, data, course):
         """

--- a/course_discovery/apps/course_metadata/data_loaders/course_loader.py
+++ b/course_discovery/apps/course_metadata/data_loaders/course_loader.py
@@ -5,6 +5,7 @@ course and course run data for the specified course type.
 """
 import csv
 import logging
+import uuid
 
 import unicodecsv
 
@@ -282,20 +283,30 @@ class CourseLoader(AbstractDataLoader, DataLoaderMixin):
         if not staff_data:
             return []
 
+        normalized_staff_uuids = []
         seen = set()
-        valid_staff_uuids = []
-        for staff_uuid in [value.strip() for value in staff_data.split(',') if value.strip()]:
-            if staff_uuid in seen:
+        for raw_value in [value.strip() for value in staff_data.split(',') if value.strip()]:
+            try:
+                normalized_uuid = str(uuid.UUID(raw_value))
+            except ValueError as exc:
+                raise ValueError(f"Invalid staff UUID format: '{raw_value}'") from exc
+
+            if normalized_uuid in seen:
                 continue
 
-            person = Person.objects.filter(uuid=staff_uuid, partner=self.partner).first()
-            if not person:
-                raise Exception(f"Instructor with UUID {staff_uuid} not found")
+            seen.add(normalized_uuid)
+            normalized_staff_uuids.append(normalized_uuid)
 
-            seen.add(staff_uuid)
-            valid_staff_uuids.append(str(person.uuid))
+        matched_staff_uuids = {
+            str(person.uuid)
+            for person in Person.objects.filter(partner=self.partner, uuid__in=normalized_staff_uuids)
+        }
 
-        return valid_staff_uuids
+        for staff_uuid in normalized_staff_uuids:
+            if staff_uuid not in matched_staff_uuids:
+                raise ValueError(f"Staff member with UUID {staff_uuid} not found for this partner")
+
+        return normalized_staff_uuids
 
     def download_course_image_assets(self, data, course):
         """

--- a/course_discovery/apps/course_metadata/data_loaders/tests/test_course_loader.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/test_course_loader.py
@@ -3,6 +3,7 @@ Unit tests for Course Loader.
 """
 import copy
 import datetime
+import re
 from tempfile import NamedTemporaryFile
 from unittest import mock
 
@@ -22,7 +23,7 @@ from course_discovery.apps.course_metadata.data_loaders.tests.mixins import CSVL
 from course_discovery.apps.course_metadata.data_loaders.tests.test_utils import MockExceptionWithResponse
 from course_discovery.apps.course_metadata.models import Course, CourseRun, CourseRunType, CourseType
 from course_discovery.apps.course_metadata.tests.factories import (
-    CourseFactory, CourseRunFactory, CourseTypeFactory, SourceFactory
+    CourseFactory, CourseRunFactory, CourseTypeFactory, PersonFactory, SourceFactory
 )
 from course_discovery.apps.course_metadata.toggles import IS_SUBDIRECTORY_SLUG_FORMAT_ENABLED
 
@@ -162,6 +163,163 @@ class TestCourseLoader(CSVLoaderMixin, OAuth2Mixin, APITestCase):
                         course=course,
                     )
                     self.assertEqual(course_run.status, CourseRunStatus.Unpublished)
+
+    def test_course_loader_ingest_for_course_creation_with_staff(self, _mock_jwt_decode_handler):
+        """
+        Test Course Loader assigns course run staff from csv UUIDs.
+        """
+        self._setup_prerequisites(self.partner)
+        self.mock_ecommerce_publication(self.partner)
+
+        staff_1 = PersonFactory(partner=self.partner)
+        staff_2 = PersonFactory(partner=self.partner)
+
+        csv_data = {
+            **mock_data.VALID_COURSE_LOADER_COURSE_AND_COURSE_RUN_CREATION_CSV_DICT,
+            'Staff': f'{staff_1.uuid}, {staff_2.uuid}',
+        }
+
+        with NamedTemporaryFile() as csv:
+            csv = self._write_csv(
+                csv, [csv_data],
+                headers=csv_data.keys()
+            )
+            # Mock studio calls - register base endpoint and use regex to match any course run key
+            studio_url = f'{self.partner.studio_url.strip("/")}/api/v1/course_runs/'
+            responses.add(responses.POST, studio_url, status=200)
+            # Match any PATCH to course run endpoint with pattern course-v1:org+number+run
+            responses.add(
+                responses.PATCH,
+                re.compile(r'.*/api/v1/course_runs/course-v1:[^/]+\+[^/]+\+[^/]+/'),
+                status=200,
+                json={}
+            )
+
+            with mock.patch.object(
+                    CourseLoader,
+                    'call_course_api',
+                    self.mock_call_course_api
+            ):
+                with mock.patch.object(
+                        CourseLoader,
+                        'download_course_image_assets',
+                        return_value=(True, True)
+                ):
+                    loader = CourseLoader(
+                        self.partner, csv_path=csv.name,
+                        product_source=self.source.slug,
+                        task_type=BulkOperationType.CourseCreate
+                    )
+                    loader.ingest()
+
+        course = Course.everything.get(key=f"{csv_data['Organization']}+{csv_data['Number']}")
+        course_run = CourseRun.everything.get(course=course)
+
+        self.assertEqual(loader.ingestion_summary['success_count'], 1)
+        self.assertSetEqual(
+            {str(person.uuid) for person in course_run.staff.all()},
+            {str(staff_1.uuid), str(staff_2.uuid)}
+        )
+
+    def test_course_loader_ingest_for_course_creation_with_invalid_staff(self, _mock_jwt_decode_handler):
+        """
+        Test Course Loader records an ingestion failure when staff UUID is invalid.
+        """
+        self._setup_prerequisites(self.partner)
+        self.mock_ecommerce_publication(self.partner)
+
+        csv_data = {
+            **mock_data.VALID_COURSE_LOADER_COURSE_AND_COURSE_RUN_CREATION_CSV_DICT,
+            'Staff': '00000000-0000-0000-0000-000000000000',
+        }
+
+        with NamedTemporaryFile() as csv:
+            csv = self._write_csv(
+                csv, [csv_data],
+                headers=csv_data.keys()
+            )
+            # Mock studio calls to accept any course run key
+            studio_url = f'{self.partner.studio_url.strip("/")}/api/v1/course_runs/'
+            responses.add(responses.POST, studio_url, status=200)
+            responses.add(
+                responses.PATCH,
+                re.compile(r'.*/api/v1/course_runs/course-v1:[^/]+\+[^/]+\+[^/]+/'),
+                status=200,
+                json={}
+            )
+
+            with mock.patch.object(
+                    CourseLoader,
+                    'call_course_api',
+                    self.mock_call_course_api
+            ):
+                with mock.patch.object(
+                        CourseLoader,
+                        'download_course_image_assets',
+                        return_value=(True, True)
+                ):
+                    loader = CourseLoader(
+                        self.partner, csv_path=csv.name,
+                        product_source=self.source.slug,
+                        task_type=BulkOperationType.CourseCreate
+                    )
+                    summary = loader.ingest()
+
+        self.assertEqual(loader.ingestion_summary['success_count'], 0)
+        self.assertEqual(loader.ingestion_summary['failure_count'], 1)
+        self.assertEqual(loader.ingestion_summary['created_products'], [])
+        self.assertTrue(summary['errors'][CSVIngestionErrors.COURSE_RUN_UPDATE_ERROR])
+        self.assertIn(
+            'Instructor with UUID 00000000-0000-0000-0000-000000000000 not found',
+            summary['errors'][CSVIngestionErrors.COURSE_RUN_UPDATE_ERROR][0]
+        )
+
+    def test_course_loader_ingest_for_partial_update_with_staff(self, _mock_jwt_decode_handler):
+        """
+        Test Course Loader updates course run staff from csv UUIDs in partial update flow.
+        """
+        self.create_new_course()
+
+        staff_1 = PersonFactory(partner=self.partner)
+        staff_2 = PersonFactory(partner=self.partner)
+
+        csv_data = {
+            **mock_data.COURSE_LOADER_COURSE_AND_COURSE_RUN_PARTIAL_UPDATES_SIMPLE,
+            'Staff': f'{staff_1.uuid}, {staff_2.uuid}',
+        }
+
+        loader, _ = self.perform_partial_updates(csv_data)
+
+        course_run = CourseRun.everything.get(key=csv_data['Course Run Key'])
+        self.assertEqual(loader.ingestion_summary['success_count'], 1)
+        self.assertSetEqual(
+            {str(person.uuid) for person in course_run.staff.all()},
+            {str(staff_1.uuid), str(staff_2.uuid)}
+        )
+
+    def test_course_loader_ingest_for_partial_update_with_invalid_staff(self, _mock_jwt_decode_handler):
+        """
+        Test Course Loader records an ingestion failure when partial update has invalid staff UUID.
+        """
+        self.create_new_course()
+
+        csv_data = {
+            **mock_data.COURSE_LOADER_COURSE_AND_COURSE_RUN_PARTIAL_UPDATES_SIMPLE,
+            'Staff': '00000000-0000-0000-0000-000000000000',
+        }
+
+        loader, _ = self.perform_partial_updates(csv_data)
+
+        course_run = CourseRun.everything.get(key=csv_data['Course Run Key'])
+
+        self.assertEqual(loader.ingestion_summary['success_count'], 0)
+        self.assertEqual(loader.ingestion_summary['failure_count'], 1)
+        self.assertTrue(loader.error_logs[CSVIngestionErrors.COURSE_RUN_UPDATE_ERROR])
+        self.assertIn(
+            'Instructor with UUID 00000000-0000-0000-0000-000000000000 not found',
+            loader.error_logs[CSVIngestionErrors.COURSE_RUN_UPDATE_ERROR][0]
+        )
+        self.assertFalse(course_run.staff.exists())
 
     @data([True, True, True], [True, False, False], [False, True, True], [False, False, True])
     @unpack

--- a/course_discovery/apps/course_metadata/data_loaders/tests/test_course_loader.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/test_course_loader.py
@@ -270,7 +270,59 @@ class TestCourseLoader(CSVLoaderMixin, OAuth2Mixin, APITestCase):
         self.assertEqual(loader.ingestion_summary['created_products'], [])
         self.assertTrue(summary['errors'][CSVIngestionErrors.COURSE_RUN_UPDATE_ERROR])
         self.assertIn(
-            'Instructor with UUID 00000000-0000-0000-0000-000000000000 not found',
+            'Staff member with UUID 00000000-0000-0000-0000-000000000000 not found for this partner',
+            summary['errors'][CSVIngestionErrors.COURSE_RUN_UPDATE_ERROR][0]
+        )
+
+    def test_course_loader_ingest_for_course_creation_with_malformed_staff_uuid(self, _mock_jwt_decode_handler):
+        """
+        Test Course Loader records an ingestion failure when staff UUID format is malformed.
+        """
+        self._setup_prerequisites(self.partner)
+        self.mock_ecommerce_publication(self.partner)
+
+        csv_data = {
+            **mock_data.VALID_COURSE_LOADER_COURSE_AND_COURSE_RUN_CREATION_CSV_DICT,
+            'Staff': 'not-a-uuid',
+        }
+
+        with NamedTemporaryFile() as csv:
+            csv = self._write_csv(
+                csv, [csv_data],
+                headers=csv_data.keys()
+            )
+            studio_url = f'{self.partner.studio_url.strip("/")}/api/v1/course_runs/'
+            responses.add(responses.POST, studio_url, status=200)
+            responses.add(
+                responses.PATCH,
+                re.compile(r'.*/api/v1/course_runs/course-v1:[^/]+\+[^/]+\+[^/]+/'),
+                status=200,
+                json={}
+            )
+
+            with mock.patch.object(
+                    CourseLoader,
+                    'call_course_api',
+                    self.mock_call_course_api
+            ):
+                with mock.patch.object(
+                        CourseLoader,
+                        'download_course_image_assets',
+                        return_value=(True, True)
+                ):
+                    loader = CourseLoader(
+                        self.partner, csv_path=csv.name,
+                        product_source=self.source.slug,
+                        task_type=BulkOperationType.CourseCreate
+                    )
+                    summary = loader.ingest()
+
+        self.assertEqual(loader.ingestion_summary['success_count'], 0)
+        self.assertEqual(loader.ingestion_summary['failure_count'], 1)
+        self.assertEqual(loader.ingestion_summary['created_products'], [])
+        self.assertTrue(summary['errors'][CSVIngestionErrors.COURSE_RUN_UPDATE_ERROR])
+        self.assertIn(
+            "Invalid staff UUID format: 'not-a-uuid'",
             summary['errors'][CSVIngestionErrors.COURSE_RUN_UPDATE_ERROR][0]
         )
 
@@ -316,7 +368,7 @@ class TestCourseLoader(CSVLoaderMixin, OAuth2Mixin, APITestCase):
         self.assertEqual(loader.ingestion_summary['failure_count'], 1)
         self.assertTrue(loader.error_logs[CSVIngestionErrors.COURSE_RUN_UPDATE_ERROR])
         self.assertIn(
-            'Instructor with UUID 00000000-0000-0000-0000-000000000000 not found',
+            'Staff member with UUID 00000000-0000-0000-0000-000000000000 not found for this partner',
             loader.error_logs[CSVIngestionErrors.COURSE_RUN_UPDATE_ERROR][0]
         )
         self.assertFalse(course_run.staff.exists())


### PR DESCRIPTION
This Pr is for[ Catalog-85](https://2u-internal.atlassian.net/browse/CATALOG-85)
Bulk course operations were not reliably handling staff assignments from CSV . I have updated the bulk CourseCreate and PartialUpdate flow to parse and validate staff UUIDs, include staff in the course run update payload, and fail clearly when an instructor UUID is invalid.
Testing:
Local UI flow validated .
Unit tests added in CourseLoader tests for valid and invalid staff scenarios.