### PR TITLE
chore: RestrictedCourseRun admin uses autocomplete_fields to select run

### DIFF
--- a/course_discovery/apps/course_metadata/admin.py
+++ b/course_discovery/apps/course_metadata/admin.py
@@ -1240,6 +1240,7 @@ class ProgramSubscriptionPriceAdmin(admin.ModelAdmin):
 class RestrictedCourseRunAdmin(admin.ModelAdmin):
     list_display = ['course_run', 'restriction_type']
     search_fields = ['course_run__key', 'restriction_type']
+    autocomplete_fields = ['course_run']
 
     def get_queryset(self, request):
         return super().get_queryset(request).select_related('course_run__course')


### PR DESCRIPTION
See https://docs.djangoproject.com/en/6.0/ref/contrib/admin/#django.contrib.admin.ModelAdmin.autocomplete_fields

This makes it so the admin page for restricted runs doesn't time out when trying to load 10,000s of possible course run records to select from.

