### PR TITLE
fix: drop orphaned b2c_subscription_inclusion column

### DIFF
--- a/course_discovery/apps/course_metadata/migrations/0357_drop_b2c_subscription_inclusion.py
+++ b/course_discovery/apps/course_metadata/migrations/0357_drop_b2c_subscription_inclusion.py
@@ -1,0 +1,25 @@
+from django.db import migrations
+
+
+def drop_column_if_exists(apps, schema_editor):
+    tables = [
+        'course_metadata_course',
+        'course_metadata_historicalcourse',
+    ]
+    for table in tables:
+        with schema_editor.connection.cursor() as cursor:
+            columns = schema_editor.connection.introspection.get_table_description(cursor, table)
+        if any(col.name == 'b2c_subscription_inclusion' for col in columns):
+            schema_editor.execute(f'ALTER TABLE {table} DROP COLUMN b2c_subscription_inclusion')
+
+
+class Migration(migrations.Migration):
+    atomic = False
+
+    dependencies = [
+        ('course_metadata', '0356_add_course_editor_update_bulk_operation'),
+    ]
+
+    operations = [
+        migrations.RunPython(drop_column_if_exists, migrations.RunPython.noop),
+    ]


### PR DESCRIPTION
## Summary

- `b2c_subscription_inclusion` was partially applied to prod when the feature was reverted, leaving the column in the DB with no migration record tracking it.
- Migration 0357 drops the column from `course_metadata_course` and `course_metadata_historicalcourse` using `atomic = False` and the Django schema introspection layer.
- No model or state changes needed since the field was already removed in the revert.

## Test plan

- [x] Run `migrate` locally against a DB with the column present -- confirm it drops cleanly
- [x] Run `migrate` locally against a DB without the column -- confirm no error
- [ ] Deploy to staging and confirm migration applies without incident

🤖 Generated with [Claude Code](https://claude.com/claude-code)