### PR TITLE
feat: bulk operations create update B2C subscription inclusion

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -1216,6 +1216,7 @@ class MinimalCourseSerializer(FlexFieldsSerializerMixin, TimestampModelSerialize
     url_slug = serializers.SerializerMethodField()
     course_type = serializers.SerializerMethodField()
     enterprise_subscription_inclusion = serializers.BooleanField(required=False)
+    b2c_subscription_inclusion = serializers.BooleanField(required=False)
     course_run_statuses = serializers.ReadOnlyField()
 
     @classmethod
@@ -1258,7 +1259,7 @@ class MinimalCourseSerializer(FlexFieldsSerializerMixin, TimestampModelSerialize
         model = Course
         fields = ('key', 'uuid', 'title', 'course_runs', 'entitlements', 'owners', 'image',
                   'short_description', 'type', 'url_slug', 'course_type', 'enterprise_subscription_inclusion',
-                  'excluded_from_seo', 'excluded_from_search', 'course_run_statuses')
+                  'b2c_subscription_inclusion', 'excluded_from_seo', 'excluded_from_search', 'course_run_statuses')
 
 
 class CourseEditorSerializer(serializers.ModelSerializer):
@@ -1360,6 +1361,7 @@ class CourseSerializer(TaggitSerializer, MinimalCourseSerializer):
     skill_names = serializers.SerializerMethodField()
     skills = serializers.SerializerMethodField()
     enterprise_subscription_inclusion = serializers.BooleanField(required=False)
+    b2c_subscription_inclusion = serializers.BooleanField(required=False)
     geolocation = GeoLocationSerializer(required=False, allow_null=True)
     location_restriction = CourseLocationRestrictionSerializer(required=False)
     in_year_value = ProductValueSerializer(required=False)
@@ -1435,7 +1437,8 @@ class CourseSerializer(TaggitSerializer, MinimalCourseSerializer):
             'enrollment_count', 'recent_enrollment_count', 'topics', 'partner', 'key_for_reruns', 'url_slug',
             'url_slug_history', 'url_redirects', 'course_run_statuses', 'editors', 'collaborators', 'skill_names',
             'skills', 'organization_short_code_override', 'organization_logo_override_url',
-            'enterprise_subscription_inclusion', 'geolocation', 'location_restriction', 'in_year_value',
+            'enterprise_subscription_inclusion', 'b2c_subscription_inclusion', 'geolocation', 'location_restriction',
+            'in_year_value',
             'product_source', 'data_modified_timestamp', 'excluded_from_search', 'excluded_from_seo', 'watchers',
         )
         read_only_fields = ('enterprise_subscription_inclusion', 'product_source', 'data_modified_timestamp')

--- a/course_discovery/apps/api/tests/test_serializers.py
+++ b/course_discovery/apps/api/tests/test_serializers.py
@@ -147,6 +147,7 @@ class MinimalCourseSerializerTests(SiteMixin, TestCase):
             'type': course.type.uuid,
             'course_type': course.type.slug,
             'enterprise_subscription_inclusion': course.enterprise_subscription_inclusion,
+            'b2c_subscription_inclusion': course.b2c_subscription_inclusion,
             'url_slug': None,
             'course_run_statuses': course.course_run_statuses,
         }
@@ -225,6 +226,7 @@ class CourseSerializerTests(MinimalCourseSerializerTests):
             'organization_short_code_override': course.organization_short_code_override,
             'organization_logo_override_url': course.organization_logo_override_url,
             'enterprise_subscription_inclusion': course.enterprise_subscription_inclusion,
+            'b2c_subscription_inclusion': course.b2c_subscription_inclusion,
             'geolocation': GeoLocationSerializer(course.geolocation).data,
             'location_restriction': CourseLocationRestrictionSerializer(
                 course.location_restriction

--- a/course_discovery/apps/course_metadata/data_loaders/course_loader.py
+++ b/course_discovery/apps/course_metadata/data_loaders/course_loader.py
@@ -489,7 +489,6 @@ class CourseLoader(AbstractDataLoader, DataLoaderMixin):
         Ingests course and courserun data for partial updates.
         """
         for row in self.reader:
-            logger.info(f"Processing row: {row}")  # Debugging line to print the current row being processed
             row = self.transform_dict_keys(row)
             course_key = row.get('course_key', '')
             course_run_key = row.get('course_run_key', '')

--- a/course_discovery/apps/course_metadata/data_loaders/course_loader.py
+++ b/course_discovery/apps/course_metadata/data_loaders/course_loader.py
@@ -208,6 +208,12 @@ class CourseLoader(AbstractDataLoader, DataLoaderMixin):
             )
             update_course_data['enterprise_subscription_inclusion'] = enterprise_subscription_inclusion
 
+        if course_data.get('b2c_subscription_inclusion', '').strip():
+            b2c_subscription_inclusion = int(
+                self.parse_boolean_string(course_data.get('b2c_subscription_inclusion', 0))
+            )
+            update_course_data['b2c_subscription_inclusion'] = b2c_subscription_inclusion
+
         if self.task_type == BulkOperationType.PartialUpdate:
             prune_empty_values(update_course_data)
 
@@ -483,6 +489,7 @@ class CourseLoader(AbstractDataLoader, DataLoaderMixin):
         Ingests course and courserun data for partial updates.
         """
         for row in self.reader:
+            logger.info(f"Processing row: {row}")  # Debugging line to print the current row being processed
             row = self.transform_dict_keys(row)
             course_key = row.get('course_key', '')
             course_run_key = row.get('course_run_key', '')

--- a/course_discovery/apps/course_metadata/data_loaders/mixins.py
+++ b/course_discovery/apps/course_metadata/data_loaders/mixins.py
@@ -168,7 +168,6 @@ class DataLoaderMixin:
         """
         Helper method to make course and course run api calls.
         """
-        
         response = self.api_client.request(
             method,
             url,

--- a/course_discovery/apps/course_metadata/data_loaders/mixins.py
+++ b/course_discovery/apps/course_metadata/data_loaders/mixins.py
@@ -168,12 +168,14 @@ class DataLoaderMixin:
         """
         Helper method to make course and course run api calls.
         """
+        
         response = self.api_client.request(
             method,
             url,
             json=data,
             headers={'content-type': 'application/json'}
         )
+        logger.info(f"Making API call to {url} with method {method} and data: {data}")
         if not response.ok:
             logger.info(f"API request failed for url {url} with response: {response.content.decode('utf-8')}")
         response.raise_for_status()
@@ -259,7 +261,13 @@ class DataLoaderMixin:
             "prices": pricing,
         }
 
-        return {
+        b2c_subscription_inclusion = None
+        if course_data.get('b2c_subscription_inclusion', '').strip():
+            b2c_subscription_inclusion = int(
+                self.parse_boolean_string(course_data.get('b2c_subscription_inclusion', ''))
+            )
+
+        payload = {
             'org': course_data['organization'],
             'title': course_data['title'],
             'number': course_data['number'],
@@ -269,15 +277,22 @@ class DataLoaderMixin:
             'course_run': course_run_creation_fields,
         }
 
+        if b2c_subscription_inclusion is not None:
+            payload['b2c_subscription_inclusion'] = b2c_subscription_inclusion
+
+        return payload
+
     def update_course(self, data, course, course_type, is_draft):
         """
         Update the course data.
         """
         course_api_url = reverse('api:v1:course-detail', kwargs={'key': course.uuid})
         url = f"{settings.DISCOVERY_BASE_URL}{course_api_url}?exclude_utm=1"
+        logger.info(f"Updating course with URL: {url} and data: {data}")  # Debugging line to print the URL and data
         request_data = self.update_course_api_request_data(data, course, course_type, is_draft)
+        logger.info(f"Request data for course update: {request_data}")  # Debugging line to print the request data
         response = self.call_course_api('PATCH', url, request_data)
-
+        logger.info(f"Course update response status code: {response.status_code}")  # Debugging line to print the response status code
         if response.status_code not in (200, 201):
             logger.info(f"Course update response: {response.content}")
         return response.json()

--- a/course_discovery/apps/course_metadata/data_loaders/mixins.py
+++ b/course_discovery/apps/course_metadata/data_loaders/mixins.py
@@ -175,7 +175,7 @@ class DataLoaderMixin:
             json=data,
             headers={'content-type': 'application/json'}
         )
-        logger.info(f"Making API call to {url} with method {method} and data: {data}")
+
         if not response.ok:
             logger.info(f"API request failed for url {url} with response: {response.content.decode('utf-8')}")
         response.raise_for_status()
@@ -288,11 +288,8 @@ class DataLoaderMixin:
         """
         course_api_url = reverse('api:v1:course-detail', kwargs={'key': course.uuid})
         url = f"{settings.DISCOVERY_BASE_URL}{course_api_url}?exclude_utm=1"
-        logger.info(f"Updating course with URL: {url} and data: {data}")  # Debugging line to print the URL and data
         request_data = self.update_course_api_request_data(data, course, course_type, is_draft)
-        logger.info(f"Request data for course update: {request_data}")  # Debugging line to print the request data
         response = self.call_course_api('PATCH', url, request_data)
-        logger.info(f"Course update response status code: {response.status_code}")  # Debugging line to print the response status code
         if response.status_code not in (200, 201):
             logger.info(f"Course update response: {response.content}")
         return response.json()

--- a/course_discovery/apps/course_metadata/data_loaders/tests/test_course_loader.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/test_course_loader.py
@@ -592,6 +592,31 @@ class TestCourseLoader(CSVLoaderMixin, OAuth2Mixin, APITestCase):
         assert course_run.min_effort is None
         assert loader.ingestion_summary["success_count"] == 1
 
+    @data(("true", True), ("false", False))
+    @unpack
+    def test_course_loader_partial_updates_b2c_subscription_inclusion(
+        self, csv_value, expected_value, mock_jwt_decode_handler  # pylint: disable=unused-argument
+    ):
+        """
+        Test that B2C subscription inclusion can be set from partial update CSV data.
+        """
+        self.create_new_course()
+
+        course = Course.everything.get()
+        course.b2c_subscription_inclusion = not expected_value
+        course.save(update_fields=["b2c_subscription_inclusion"])
+
+        csv_data = {
+            "Course Key": "edx+csv-123",
+            "B2C Subscription Inclusion": csv_value,
+        }
+
+        loader, _ = self.perform_partial_updates(csv_data)
+
+        course.refresh_from_db()
+        assert course.b2c_subscription_inclusion is expected_value
+        assert loader.ingestion_summary["success_count"] == 1
+
     def test_course_loader_ingest_for_course_creation_skip_if_exists(self, mock_jwt_decode_handler):  # pylint: disable=unused-argument
         """
         Test Course Loader for course creation.


### PR DESCRIPTION
This PR adds support for a new b2c_subscription_inclusion on Course, wiring it through the Course API serializers (and serializer tests) and enabling bulk CSV loaders to include/update the field during course create/update operations.