### PR TITLE
feat: migrate Snowflake authentication to key pair auth

### DIFF
--- a/course_discovery/apps/course_metadata/management/commands/populate_course_length.py
+++ b/course_discovery/apps/course_metadata/management/commands/populate_course_length.py
@@ -3,12 +3,11 @@ Django management command to populate course_length in Course model by fetching 
 """
 import logging
 
-import snowflake.connector
-from django.conf import settings
 from django.core.management import BaseCommand
 
 from course_discovery.apps.course_metadata.constants import SNOWFLAKE_POPULATE_COURSE_LENGTH_QUERY
 from course_discovery.apps.course_metadata.models import Course
+from course_discovery.apps.course_metadata.snowflake import get_snowflake_connection
 
 LOGGER = logging.getLogger(__name__)
 
@@ -35,12 +34,7 @@ class Command(BaseCommand):
         """
         Get query results from Snowflake and yield each row.
         """
-        ctx = snowflake.connector.connect(
-            user=settings.SNOWFLAKE_SERVICE_USER,
-            password=settings.SNOWFLAKE_SERVICE_USER_PASSWORD,
-            account='edx.us-east-1',
-            database='prod'
-        )
+        ctx = get_snowflake_connection()
         cs = ctx.cursor()
         try:
             cs.execute(SNOWFLAKE_POPULATE_COURSE_LENGTH_QUERY)
@@ -48,7 +42,7 @@ class Command(BaseCommand):
             yield from rows
         finally:
             cs.close()
-        ctx.close()
+            ctx.close()
 
     def handle(self, *args, **options):
         should_commit = not options['no_commit']

--- a/course_discovery/apps/course_metadata/management/commands/refresh_course_reviews.py
+++ b/course_discovery/apps/course_metadata/management/commands/refresh_course_reviews.py
@@ -3,12 +3,11 @@ Django management command to fetch Outcome surveys from Snowflake and add them i
 """
 import logging
 
-import snowflake.connector
-from django.conf import settings
 from django.core.management import BaseCommand, CommandError
 
 from course_discovery.apps.course_metadata.constants import SNOWFLAKE_REFRESH_COURSE_REVIEWS_QUERY
 from course_discovery.apps.course_metadata.models import CourseReview
+from course_discovery.apps.course_metadata.snowflake import get_snowflake_connection
 
 LOGGER = logging.getLogger(__name__)
 
@@ -36,12 +35,7 @@ class Command(BaseCommand):
         Get query results from Snowflake and yield each row.
         """
 
-        ctx = snowflake.connector.connect(
-            user=settings.SNOWFLAKE_SERVICE_USER,
-            password=settings.SNOWFLAKE_SERVICE_USER_PASSWORD,
-            account=settings.SNOWFLAKE_ACCOUNT,
-            database=settings.SNOWFLAKE_DATABASE
-        )
+        ctx = get_snowflake_connection()
         cs = ctx.cursor()
         try:
             cs.execute(SNOWFLAKE_REFRESH_COURSE_REVIEWS_QUERY)
@@ -49,7 +43,7 @@ class Command(BaseCommand):
             yield from rows
         finally:
             cs.close()
-        ctx.close()
+            ctx.close()
 
     def handle(self, *args, **options):
         should_commit = not options['dry_run']

--- a/course_discovery/apps/course_metadata/snowflake.py
+++ b/course_discovery/apps/course_metadata/snowflake.py
@@ -1,0 +1,44 @@
+import snowflake.connector
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives.serialization import Encoding, NoEncryption, PrivateFormat, load_pem_private_key
+from django.conf import settings
+
+
+def build_private_key_bytes(private_key_pem, passphrase=None):
+    """
+    Convert PEM private key into DER bytes required by Snowflake.
+    """
+    passphrase_bytes = passphrase.encode('utf-8') if passphrase else None
+
+    p_key = load_pem_private_key(
+        private_key_pem.encode('utf-8'),
+        password=passphrase_bytes,
+        backend=default_backend(),
+    )
+
+    return p_key.private_bytes(
+        encoding=Encoding.DER,
+        format=PrivateFormat.PKCS8,
+        encryption_algorithm=NoEncryption(),
+    )
+
+
+def get_snowflake_connection():
+    """
+    Create Snowflake connection using key pair authentication.
+    """
+    connection_kwargs = {
+        'user': settings.SNOWFLAKE_SERVICE_USER,
+        'private_key': build_private_key_bytes(
+            settings.SNOWFLAKE_SERVICE_PRIVKEY,
+            getattr(settings, 'SNOWFLAKE_SERVICE_PASSPHRASE', None),
+        ),
+        'account': settings.SNOWFLAKE_ACCOUNT,
+        'database': settings.SNOWFLAKE_DATABASE,
+    }
+
+    role = getattr(settings, 'SNOWFLAKE_ROLE', None)
+    if role:
+        connection_kwargs['role'] = role
+
+    return snowflake.connector.connect(**connection_kwargs)

--- a/course_discovery/apps/course_metadata/tests/test_snowflake.py
+++ b/course_discovery/apps/course_metadata/tests/test_snowflake.py
@@ -1,0 +1,126 @@
+from unittest import mock
+
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives.serialization import BestAvailableEncryption, Encoding, NoEncryption, PrivateFormat
+from django.test import TestCase
+
+from course_discovery.apps.course_metadata.snowflake import build_private_key_bytes, get_snowflake_connection
+
+
+class TestSnowflakeHelpers(TestCase):
+    """Tests for Snowflake helper functions."""
+
+    def _generate_pem_key(self, passphrase=None):
+        private_key = rsa.generate_private_key(
+            public_exponent=65537,
+            key_size=2048,
+            backend=default_backend(),
+        )
+
+        encryption = (
+            BestAvailableEncryption(passphrase.encode("utf-8"))
+            if passphrase
+            else NoEncryption()
+        )
+
+        return private_key.private_bytes(
+            encoding=Encoding.PEM,
+            format=PrivateFormat.PKCS8,
+            encryption_algorithm=encryption,
+        ).decode("utf-8")
+
+    def test_build_private_key_bytes_without_passphrase(self):
+        pem = self._generate_pem_key()
+
+        result = build_private_key_bytes(pem)
+
+        self.assertIsInstance(result, bytes)
+        self.assertEqual(result[0], 0x30)
+
+    def test_build_private_key_bytes_with_passphrase(self):
+        passphrase = "test-passphrase"
+
+        pem = self._generate_pem_key(passphrase=passphrase)
+
+        result = build_private_key_bytes(pem, passphrase)
+
+        self.assertIsInstance(result, bytes)
+        self.assertEqual(result[0], 0x30)
+
+    @mock.patch(
+        "course_discovery.apps.course_metadata.snowflake.build_private_key_bytes"
+    )
+    @mock.patch(
+        "course_discovery.apps.course_metadata.snowflake.snowflake.connector.connect"
+    )
+    @mock.patch(
+        "course_discovery.apps.course_metadata.snowflake.settings"
+    )
+    def test_get_snowflake_connection(
+        self,
+        mock_settings,
+        mock_connect,
+        mock_build_private_key,
+    ):
+        mock_settings.SNOWFLAKE_SERVICE_USER = "ENTERPRISE_SERVICE_USER"
+        mock_settings.SNOWFLAKE_SERVICE_PRIVKEY = "private-key"
+        mock_settings.SNOWFLAKE_SERVICE_PASSPHRASE = "passphrase"
+        mock_settings.SNOWFLAKE_ACCOUNT = "edx.us-east-1"
+        mock_settings.SNOWFLAKE_DATABASE = "prod"
+        mock_settings.SNOWFLAKE_ROLE = "ENTERPRISE_SERVICE_USER_ROLE"
+
+        mock_build_private_key.return_value = b"fake-private-key"
+
+        get_snowflake_connection()
+
+        mock_build_private_key.assert_called_once_with(
+            "private-key",
+            "passphrase",
+        )
+
+        mock_connect.assert_called_once_with(
+            user="ENTERPRISE_SERVICE_USER",
+            private_key=b"fake-private-key",
+            account="edx.us-east-1",
+            database="prod",
+            role="ENTERPRISE_SERVICE_USER_ROLE",
+        )
+
+    @mock.patch(
+        "course_discovery.apps.course_metadata.snowflake.build_private_key_bytes"
+    )
+    @mock.patch(
+        "course_discovery.apps.course_metadata.snowflake.snowflake.connector.connect"
+    )
+    @mock.patch(
+        "course_discovery.apps.course_metadata.snowflake.settings"
+    )
+    def test_get_snowflake_connection_without_role(
+        self,
+        mock_settings,
+        mock_connect,
+        mock_build_private_key,
+    ):
+        mock_settings.SNOWFLAKE_SERVICE_USER = "ENTERPRISE_SERVICE_USER"
+        mock_settings.SNOWFLAKE_SERVICE_PRIVKEY = "private-key"
+        mock_settings.SNOWFLAKE_SERVICE_PASSPHRASE = "passphrase"
+        mock_settings.SNOWFLAKE_ACCOUNT = "edx.us-east-1"
+        mock_settings.SNOWFLAKE_DATABASE = "prod"
+        mock_settings.SNOWFLAKE_ROLE = None
+
+        mock_build_private_key.return_value = b"fake-private-key"
+
+        get_snowflake_connection()
+
+        mock_build_private_key.assert_called_once_with(
+            "private-key",
+            "passphrase",
+        )
+
+        mock_connect.assert_called_once_with(
+            user="ENTERPRISE_SERVICE_USER",
+            private_key=b"fake-private-key",
+            account="edx.us-east-1",
+            database="prod",
+        )


### PR DESCRIPTION
This PR migrates Course Discovery Snowflake integrations from username/password authentication to Snowflake key-pair authentication.

JIRA Ticket : https://2u-internal.atlassian.net/browse/CATALOG-143

The change updates the Snowflake connection logic used by:

- refresh_course_reviews
- populate_course_length

A shared helper has been introduced to centralize Snowflake connection creation and private key handling.

## Changes

- Added Snowflake helper utilities for key-pair authentication.
- Added private key loading using the cryptography library.
- Updated refresh_course_reviews command to use the shared helper.
- Updated populate_course_length command to use the shared helper.
- Added unit tests covering private key conversion functionality.

## Validation

### Snowflake Helper Tests
Passed locally.

### Existing Management Command Tests
Passed locally.

- test_refresh_course_reviews.py
- test_populate_course_length.py
- test_snowflake.py

<img width="931" height="277" alt="test_snowflake" src="https://github.com/user-attachments/assets/03c55738-d60b-4da2-a251-f946883b8265" />
<img width="931" height="275" alt="test_populate_course_length" src="https://github.com/user-attachments/assets/34df7ac7-06a8-4f07-84a1-656ed1a314be" />
<img width="807" height="280" alt="test_refresh_course_reviews" src="https://github.com/user-attachments/assets/3b4661ca-d79c-4488-bcb4-1556ebac2ae2" />
