### PR TITLE
feat: B2C Subscription Inclusion Flag for Program Algolia Reindex

### DIFF
--- a/course_discovery/apps/course_metadata/algolia_models.py
+++ b/course_discovery/apps/course_metadata/algolia_models.py
@@ -751,6 +751,22 @@ class AlgoliaProxyProgram(Program, AlgoliaBasicModelFieldsMixin):
         else:
             return None
 
+    @property
+    def b2c_subscription_inclusion(self):
+        """
+        Return the b2c_subscription_inclusion value from the Program model for Algolia indexing.
+        This field indicates if the program is included in the B2C subscription catalog.
+        """
+        # Check if value was explicitly set via setter (e.g., from data loaders)
+        if '_b2c_subscription_inclusion' in self.__dict__:
+            return self.__dict__['_b2c_subscription_inclusion']
+        # Otherwise return the actual model field value from the database
+        return self.__dict__.get('b2c_subscription_inclusion', False)
+
+    @b2c_subscription_inclusion.setter
+    def b2c_subscription_inclusion(self, value):
+        self.__dict__['_b2c_subscription_inclusion'] = value
+
 
 class SearchDefaultResultsConfiguration(models.Model):
     index_name = models.CharField(max_length=32, unique=True)

--- a/course_discovery/apps/course_metadata/tests/test_algolia_models.py
+++ b/course_discovery/apps/course_metadata/tests/test_algolia_models.py
@@ -963,3 +963,43 @@ class TestAlgoliaProxyProgram(TestAlgoliaProxyWithEdxPartner):
             'translation_languages': [],
             'transcription_languages': []
         }
+
+    def test_b2c_subscription_inclusion_default_for_programs(self):
+        """Test that b2c_subscription_inclusion defaults to False for programs."""
+        program = AlgoliaProxyProgramFactory(partner=self.__class__.edxPartner)
+        assert program.b2c_subscription_inclusion is False
+
+    def test_b2c_subscription_inclusion_true_for_programs(self):
+        """Test that b2c_subscription_inclusion can be set to True for programs."""
+        program = AlgoliaProxyProgramFactory(
+            partner=self.__class__.edxPartner, b2c_subscription_inclusion=True
+        )
+        assert program.b2c_subscription_inclusion is True
+
+    def test_b2c_subscription_inclusion_retrieves_from_dict(self):
+        """Test that b2c_subscription_inclusion retrieves value from __dict__ for programs."""
+        program = AlgoliaProxyProgramFactory(
+            partner=self.__class__.edxPartner, b2c_subscription_inclusion=True
+        )
+        # Retrieve fresh instance to ensure field is loaded from database
+        program_fresh = AlgoliaProxyProgram.objects.get(pk=program.pk)
+        # Should retrieve the value from __dict__ where Django stores model field values
+        assert program_fresh.b2c_subscription_inclusion is True
+
+    def test_b2c_subscription_inclusion_false_persistence(self):
+        """Test that b2c_subscription_inclusion=False is properly persisted and retrieved for programs."""
+        program = AlgoliaProxyProgramFactory(
+            partner=self.__class__.edxPartner, b2c_subscription_inclusion=False
+        )
+        # Retrieve fresh instance to verify persistence
+        program_fresh = AlgoliaProxyProgram.objects.get(pk=program.pk)
+        assert program_fresh.b2c_subscription_inclusion is False
+
+    def test_b2c_subscription_inclusion_accessed_when_field_not_loaded(self):
+        """Test b2c_subscription_inclusion returns False when field hasn't been loaded yet."""
+        program = AlgoliaProxyProgramFactory(partner=self.__class__.edxPartner)
+        # Manually clear __dict__ to simulate field not being loaded
+        if 'b2c_subscription_inclusion' in program.__dict__:
+            del program.__dict__['b2c_subscription_inclusion']
+        # Should return False as default
+        assert program.b2c_subscription_inclusion is False


### PR DESCRIPTION
https://2u-internal.atlassian.net/browse/SUBS-820
Ensure Program subscription data, including the B2C Subscription Inclusion flag, is indexed in Algolia so eligible Programs can be Sync.

Program subscription flag is indexed.
Index updates after Program changes.
Ensure program subscription data is successfully synchronized with the corresponding Algolia product index.
