### PR TITLE
feat: validate B2C course eligibility for B2C programs

### DIFF
--- a/course_discovery/apps/course_metadata/forms.py
+++ b/course_discovery/apps/course_metadata/forms.py
@@ -92,17 +92,41 @@ class ProgramAdminForm(forms.ModelForm):
 
     def clean(self):
 
-        super().clean()
+        cleaned_data = super().clean()
 
-        status = self.cleaned_data.get('status')
-        banner_image = self.cleaned_data.get('banner_image')
+        status = cleaned_data.get('status')
+        banner_image = cleaned_data.get('banner_image')
+        b2c_subscription_inclusion = cleaned_data.get('b2c_subscription_inclusion')
+        courses = cleaned_data.get('courses')
+        if courses is None:
+            courses = Course.objects.none()
 
         if status == ProgramStatus.Active and not banner_image:
             raise ValidationError(_(
                 'Programs can only be activated if they have a banner image.'
             ))
 
-        return self.cleaned_data
+        if b2c_subscription_inclusion:
+            if hasattr(courses, 'filter'):
+                invalid_titles = list(
+                    courses.filter(b2c_subscription_inclusion=False)
+                    .order_by('title')
+                    .values_list('title', flat=True)
+                )
+            else:
+                invalid_titles = list(
+                    Course.objects.filter(
+                        id__in=[course.id for course in courses],
+                        b2c_subscription_inclusion=False,
+                    ).order_by('title').values_list('title', flat=True)
+                )
+            if invalid_titles:
+                raise ValidationError(_(
+                    'All courses in a B2C subscription program must support B2C subscription inclusion. '
+                    'Remove or update the following courses before saving: %(courses)s.'
+                ), params={'courses': ', '.join(invalid_titles)})
+
+        return cleaned_data
 
     def clean_authoring_organizations(self):
         """

--- a/course_discovery/apps/course_metadata/tests/test_forms.py
+++ b/course_discovery/apps/course_metadata/tests/test_forms.py
@@ -70,3 +70,75 @@ class ProgramAdminFormTests(SiteMixin, TestCase):
         form = ProgramAdminForm(data=data)
 
         self.assertTrue(form.is_valid())
+
+    def test_b2c_program_with_only_b2c_courses_can_be_saved(self):
+        enabled_course_1 = factories.CourseFactory(
+            title='B2C-enabled course 1',
+            b2c_subscription_inclusion=True,
+        )
+        enabled_course_2 = factories.CourseFactory(
+            title='B2C-enabled course 2',
+            b2c_subscription_inclusion=True,
+        )
+
+        data = self._post_data(status=ProgramStatus.Unpublished)
+        data['authoring_organizations'] = []
+        data['courses'] = [enabled_course_1.id, enabled_course_2.id]
+        data['b2c_subscription_inclusion'] = 'on'
+
+        form = ProgramAdminForm(data=data)
+        self.assertTrue(form.is_valid())
+
+        program = form.save()
+        self.assertTrue(program.b2c_subscription_inclusion)
+        self.assertEqual(list(program.courses.order_by('id')), [enabled_course_1, enabled_course_2])
+
+    def test_b2c_program_with_non_b2c_course_cannot_be_saved(self):
+        enabled_course = factories.CourseFactory(
+            title='B2C-enabled course',
+            b2c_subscription_inclusion=True,
+        )
+        disabled_course = factories.CourseFactory(
+            title='Non-B2C course',
+            b2c_subscription_inclusion=False,
+        )
+        disabled_course_2 = factories.CourseFactory(
+            title='Non-B2C course 2',
+            b2c_subscription_inclusion=False,
+        )
+
+        data = self._post_data(status=ProgramStatus.Unpublished)
+        data['authoring_organizations'] = []
+        data['courses'] = [enabled_course.id, disabled_course.id, disabled_course_2.id]
+        data['b2c_subscription_inclusion'] = 'on'
+
+        form = ProgramAdminForm(data=data)
+        self.assertFalse(form.is_valid())
+        self.assertEqual(
+            form.errors['__all__'],
+            [
+                'All courses in a B2C subscription program must support B2C subscription inclusion. '
+                'Remove or update the following courses before saving: Non-B2C course, Non-B2C course 2.'
+            ]
+        )
+
+    def test_non_b2c_program_can_be_saved_with_mixed_courses(self):
+        enabled_course = factories.CourseFactory(
+            title='B2C-enabled course',
+            b2c_subscription_inclusion=True,
+        )
+        disabled_course = factories.CourseFactory(
+            title='Non-B2C course',
+            b2c_subscription_inclusion=False,
+        )
+
+        data = self._post_data(status=ProgramStatus.Unpublished)
+        data['authoring_organizations'] = []
+        data['courses'] = [enabled_course.id, disabled_course.id]
+
+        form = ProgramAdminForm(data=data)
+        self.assertTrue(form.is_valid())
+
+        program = form.save()
+        self.assertFalse(program.b2c_subscription_inclusion)
+        self.assertEqual(list(program.courses.order_by('id')), [enabled_course, disabled_course])


### PR DESCRIPTION
This PR adds validation to ensure that Programs with b2c_subscription_inclusion=True can only contain Courses with b2c_subscription_inclusion=True.

**Changes**

- Added validation in ProgramAdminForm to prevent saving a B2C Program containing non-B2C Courses.
- Displayed a validation error listing the non-compliant Course(s) when validation fails.
- Kept the existing Program validation behavior unchanged.
- Refactored the form validation to use cleaned_data and queryset filtering for improved readability and maintainability.