### PR TITLE
feat: B2C Subscription Inclusion Flag for Program Algolia Reindex

### DIFF
--- a/course_discovery/apps/course_metadata/algolia_models.py
+++ b/course_discovery/apps/course_metadata/algolia_models.py
@@ -494,11 +494,7 @@ class AlgoliaProxyCourse(Course, AlgoliaBasicModelFieldsMixin):
         """Return the stored b2c_subscription_inclusion value for persistence and Algolia indexing."""
         return self.__dict__.get('_b2c_subscription_inclusion', False)
 
-    @b2c_subscription_inclusion.setter
-    def b2c_subscription_inclusion(self, value):
-        self.__dict__['_b2c_subscription_inclusion'] = value
-
-
+   
 class AlgoliaProxyProgram(Program, AlgoliaBasicModelFieldsMixin):
 
     class Meta:
@@ -754,12 +750,7 @@ class AlgoliaProxyProgram(Program, AlgoliaBasicModelFieldsMixin):
     @property
     def b2c_subscription_inclusion(self):
         """Return the stored b2c_subscription_inclusion value for persistence and Algolia indexing."""
-        return self.__dict__.get('_b2c_subscription_inclusion', self.__dict__.get('b2c_subscription_inclusion', False))
-
-    @b2c_subscription_inclusion.setter
-    def b2c_subscription_inclusion(self, value):
-        self.__dict__['_b2c_subscription_inclusion'] = value
-
+        return self.__dict__.get('_b2c_subscription_inclusion', False)
 
 class SearchDefaultResultsConfiguration(models.Model):
     index_name = models.CharField(max_length=32, unique=True)

--- a/course_discovery/apps/course_metadata/tests/test_algolia_models.py
+++ b/course_discovery/apps/course_metadata/tests/test_algolia_models.py
@@ -965,7 +965,7 @@ class TestAlgoliaProxyProgram(TestAlgoliaProxyWithEdxPartner):
         }
 
     def test_b2c_subscription_inclusion_default_for_programs(self):
-        """Test that b2c_subscription_inclusion defaults to False for programs."""
+        """Test that b2c_subscription_inclusion defaults to False."""
         program = AlgoliaProxyProgramFactory(partner=self.__class__.edxPartner)
         assert program.b2c_subscription_inclusion is False
 
@@ -979,7 +979,7 @@ class TestAlgoliaProxyProgram(TestAlgoliaProxyWithEdxPartner):
         assert program_fresh.b2c_subscription_inclusion is False
 
     def test_b2c_subscription_inclusion_true_persistence(self):
-        """Test that b2c_subscription_inclusion=True is properly persisted and retrieved for programs."""
+        """Test the b2c_subscription_inclusion=True is properly persisted and retrieved for programs."""
         program = AlgoliaProxyProgramFactory(
             partner=self.__class__.edxPartner, b2c_subscription_inclusion=True
         )


### PR DESCRIPTION
https://2u-internal.atlassian.net/browse/SUBS-820
Ensure Program subscription data, including the B2C Subscription Inclusion flag, is indexed in Algolia so eligible Programs can be Sync.

Program subscription flag is indexed.
Index updates after Program changes.
Ensure program subscription data is successfully synchronized with the corresponding Algolia product index.