### PR TITLE
feat: B2C Subscription Inclusion Flag for Program Algolia Reindex

### DIFF
--- a/course_discovery/apps/course_metadata/algolia_models.py
+++ b/course_discovery/apps/course_metadata/algolia_models.py
@@ -491,8 +491,8 @@ class AlgoliaProxyCourse(Course, AlgoliaBasicModelFieldsMixin):
 
     @property
     def b2c_subscription_inclusion(self):
-        """Return the b2c_subscription_inclusion value from the underlying Course instance in Course."""
-        return getattr(self, '_b2c_subscription_inclusion', self.product.b2c_subscription_inclusion)
+        """Return the stored b2c_subscription_inclusion value for persistence and Algolia indexing."""
+        return self.__dict__.get('_b2c_subscription_inclusion', False)
 
     @b2c_subscription_inclusion.setter
     def b2c_subscription_inclusion(self, value):
@@ -753,8 +753,8 @@ class AlgoliaProxyProgram(Program, AlgoliaBasicModelFieldsMixin):
 
     @property
     def b2c_subscription_inclusion(self):
-        """Return the b2c_subscription_inclusion value from the underlying Program instance for the Program."""
-        return getattr(self, '_b2c_subscription_inclusion', self.product.b2c_subscription_inclusion)
+        """Return the stored b2c_subscription_inclusion value for persistence and Algolia indexing."""
+        return self.__dict__.get('_b2c_subscription_inclusion', self.__dict__.get('b2c_subscription_inclusion', False))
 
     @b2c_subscription_inclusion.setter
     def b2c_subscription_inclusion(self, value):

--- a/course_discovery/apps/course_metadata/algolia_models.py
+++ b/course_discovery/apps/course_metadata/algolia_models.py
@@ -491,8 +491,8 @@ class AlgoliaProxyCourse(Course, AlgoliaBasicModelFieldsMixin):
 
     @property
     def b2c_subscription_inclusion(self):
-        """Return the stored b2c_subscription_inclusion value for persistence and Algolia indexing."""
-        return self.__dict__.get('_b2c_subscription_inclusion', False)
+        """Return the b2c_subscription_inclusion value from the underlying Course instance in Course."""
+        return getattr(self, '_b2c_subscription_inclusion', self.product.b2c_subscription_inclusion)
 
     @b2c_subscription_inclusion.setter
     def b2c_subscription_inclusion(self, value):
@@ -753,8 +753,8 @@ class AlgoliaProxyProgram(Program, AlgoliaBasicModelFieldsMixin):
 
     @property
     def b2c_subscription_inclusion(self):
-        """Return the stored b2c_subscription_inclusion value for persistence and Algolia indexing."""
-        return self.__dict__.get('_b2c_subscription_inclusion', self.__dict__.get('b2c_subscription_inclusion', False))
+        """Return the b2c_subscription_inclusion value from the underlying Program instance for the Program."""
+        return getattr(self, '_b2c_subscription_inclusion', self.product.b2c_subscription_inclusion)
 
     @b2c_subscription_inclusion.setter
     def b2c_subscription_inclusion(self, value):

--- a/course_discovery/apps/course_metadata/tests/test_algolia_models.py
+++ b/course_discovery/apps/course_metadata/tests/test_algolia_models.py
@@ -995,3 +995,25 @@ class TestAlgoliaProxyProgram(TestAlgoliaProxyWithEdxPartner):
             del program.__dict__['b2c_subscription_inclusion']
         # Should return False as default
         assert program.b2c_subscription_inclusion is False
+
+    def test_b2c_subscription_inclusion_retrieved_from_product_for_courses(self):
+        """Test that b2c_subscription_inclusion is retrieved from the underlying product for courses."""
+        course = CourseFactory(partner=self.__class__.edxPartner, b2c_subscription_inclusion=True)
+        proxy_course = AlgoliaProxyCourse(product=course)
+        assert proxy_course.b2c_subscription_inclusion is True
+
+        course.b2c_subscription_inclusion = False
+        course.save()
+        proxy_course_updated = AlgoliaProxyCourse(product=course)
+        assert proxy_course_updated.b2c_subscription_inclusion is False
+
+    def test_b2c_subscription_inclusion_retrieved_from_product_for_programs(self):
+        """Test that b2c_subscription_inclusion is retrieved from the underlying product for programs."""
+        program = ProgramFactory(partner=self.__class__.edxPartner, b2c_subscription_inclusion=True)
+        proxy_program = AlgoliaProxyProgram(product=program)
+        assert proxy_program.b2c_subscription_inclusion is True
+
+        program.b2c_subscription_inclusion = False
+        program.save()
+        proxy_program_updated = AlgoliaProxyProgram(product=program)
+        assert proxy_program_updated.b2c_subscription_inclusion is False

--- a/course_discovery/apps/course_metadata/tests/test_algolia_models.py
+++ b/course_discovery/apps/course_metadata/tests/test_algolia_models.py
@@ -997,23 +997,23 @@ class TestAlgoliaProxyProgram(TestAlgoliaProxyWithEdxPartner):
         assert program.b2c_subscription_inclusion is False
 
     def test_b2c_subscription_inclusion_retrieved_from_product_for_courses(self):
-        """Test that b2c_subscription_inclusion is retrieved from the underlying product for courses."""
+        """Test that b2c_subscription_inclusion is retrieved from the underlying course for AlgoliaProxyCourse."""
         course = CourseFactory(partner=self.__class__.edxPartner, b2c_subscription_inclusion=True)
-        proxy_course = AlgoliaProxyCourse(product=course)
+        proxy_course = AlgoliaProxyCourse.objects.get(pk=course.pk)
         assert proxy_course.b2c_subscription_inclusion is True
 
         course.b2c_subscription_inclusion = False
         course.save()
-        proxy_course_updated = AlgoliaProxyCourse(product=course)
+        proxy_course_updated = AlgoliaProxyCourse.objects.get(pk=course.pk)
         assert proxy_course_updated.b2c_subscription_inclusion is False
 
     def test_b2c_subscription_inclusion_retrieved_from_product_for_programs(self):
-        """Test that b2c_subscription_inclusion is retrieved from the underlying product for programs."""
+        """Test that b2c_subscription_inclusion is retrieved from the underlying program for AlgoliaProxyProgram."""
         program = ProgramFactory(partner=self.__class__.edxPartner, b2c_subscription_inclusion=True)
-        proxy_program = AlgoliaProxyProgram(product=program)
+        proxy_program = AlgoliaProxyProgram.objects.get(pk=program.pk)
         assert proxy_program.b2c_subscription_inclusion is True
 
         program.b2c_subscription_inclusion = False
         program.save()
-        proxy_program_updated = AlgoliaProxyProgram(product=program)
+        proxy_program_updated = AlgoliaProxyProgram.objects.get(pk=program.pk)
         assert proxy_program_updated.b2c_subscription_inclusion is False


### PR DESCRIPTION
https://2u-internal.atlassian.net/browse/SUBS-820
Ensure Program subscription data, including the B2C Subscription Inclusion flag, is indexed in Algolia so eligible Programs can be Sync.

Program subscription flag is indexed.
Index updates after Program changes.
Ensure program subscription data is successfully synchronized with the corresponding Algolia product index.