### PR TITLE
fix: prevent course deadline reminders when subsequent course run exists

### DIFF
--- a/course_discovery/apps/course_metadata/management/commands/send_course_deadline_emails.py
+++ b/course_discovery/apps/course_metadata/management/commands/send_course_deadline_emails.py
@@ -43,8 +43,7 @@ class Command(BaseCommand):
         logger.info("Initializing course deadline email management command.")
         now = datetime.now(timezone.utc)
         courses_with_deadlines = []
-        # Include both Self-paced and Instructor-paced
-        courses_with_runs = Course.objects.filter(
+        matching_course_ids = Course.objects.filter(
             course_runs__pacing_type__in=[CourseRunPacing.Self, CourseRunPacing.Instructor],
             course_runs__end__isnull=False,
             product_source__slug=settings.DEFAULT_PRODUCT_SOURCE_SLUG,
@@ -54,10 +53,14 @@ class Command(BaseCommand):
                 output_field=DurationField())
         ).filter(
             days_until_end__in=[timedelta(days=d) for d in EMAIL_DELTA_DAYS]
+        ).values_list('pk', flat=True).distinct()
+
+        courses_with_runs = Course.objects.filter(
+            pk__in=matching_course_ids,
         ).prefetch_related(
             'course_runs',
             'editors',
-        ).distinct()
+        )
         logger.info(f'Found {courses_with_runs.count()} courses with matching runs.')
         courses_with_runs = courses_with_runs.iterator(chunk_size=settings.ITERATOR_CHUNK_SIZE)
 
@@ -65,7 +68,14 @@ class Command(BaseCommand):
             advertised_run = course.advertised_course_run
 
             if advertised_run:
-                if not course.course_runs.filter(status=CourseRunStatus.Reviewed).exists():
+                if not advertised_run.end:
+                    logger.info(
+                        f"Course {course.title} ({course.key}) advertised course run "
+                        f"has no end date; skipping deadline reminder."
+                    )
+                    continue
+
+                if not self.has_subsequent_course_run(course, advertised_run):
                     days_until_end = (advertised_run.end.date() - now.date()).days
                     if days_until_end in EMAIL_DELTA_DAYS:
                         self.handle_send_email_to_pcs_and_editors(
@@ -77,16 +87,24 @@ class Command(BaseCommand):
                                     f"with end date within the specified range.")
                 else:
                     logger.info(
-                        f"Course {course.title} ({course.key}) has an active course run with status Scheduled."
+                        f"Course {course.title} ({course.key}) has a subsequent active course run."
                     )
 
-            elif not advertised_run:
-                last_course_run = course.course_runs.last()
-                days_since_end = (last_course_run.end.date() - now.date()).days
+            else:
+                latest_course_run = self.get_latest_course_run(course)
+
+                if not latest_course_run or not latest_course_run.end:
+                    logger.info(
+                        f"Course {course.title} ({course.key}) has no course run "
+                        f"with end date within the specified range."
+                    )
+                    continue
+
+                days_since_end = (latest_course_run.end.date() - now.date()).days
 
                 if days_since_end == LAST_RUN_END_DELTA:
                     self.handle_send_email_to_pcs_and_editors(
-                        course, last_course_run, email_variant=self.DEADLINE_VARIANTS.get(days_since_end)
+                        course, latest_course_run, email_variant=self.DEADLINE_VARIANTS.get(days_since_end)
                     )
                     courses_with_deadlines.append(course)
                     logger.info(f'Deadline email has been scheduled for course {course.title} ({course.key}).')
@@ -114,6 +132,41 @@ class Command(BaseCommand):
         logger.info(f"Scheduling deadline email for course {course.title} ({course.key}).")
         process_send_course_deadline_email.apply_async(
             args=[course.key, course_run.key, recipients, email_variant],
+        )
+
+    def has_subsequent_course_run(self, course, course_run):
+        """
+        Return True when the course already has a later reviewed or published run.
+        """
+        reference_key = self.get_course_run_sort_key(course_run)
+        candidate_runs = course.course_runs.filter(
+            status__in=[CourseRunStatus.Reviewed, CourseRunStatus.Published],
+        ).exclude(pk=course_run.pk)
+
+        return any(self.get_course_run_sort_key(run) > reference_key for run in candidate_runs)
+
+    def get_latest_course_run(self, course):
+        """
+        Return the most recent course run using a deterministic sort key.
+        """
+        course_runs = list(course.course_runs.all())
+        if not course_runs:
+            return None
+
+        return max(course_runs, key=self.get_course_run_sort_key)
+
+    @staticmethod
+    def get_course_run_sort_key(course_run):
+        """
+        Sort course runs by their best available chronology fields.
+        """
+        min_datetime = datetime.min.replace(tzinfo=timezone.utc)
+        primary_schedule_date = course_run.start or course_run.end or min_datetime
+        return (
+            primary_schedule_date,
+            course_run.end or min_datetime,
+            course_run.created or min_datetime,
+            course_run.pk or 0,
         )
 
     def log_courses_with_deadlines(self, courses):

--- a/course_discovery/apps/course_metadata/management/commands/tests/test_send_course_deadline_emails.py
+++ b/course_discovery/apps/course_metadata/management/commands/tests/test_send_course_deadline_emails.py
@@ -153,13 +153,14 @@ class SendCourseDeadlineEmailsTests(TestCase):
 
         self.assertEqual(called_kwargs['args'], expected_args)
 
-    def test_with_course_run_with_end_date_within_range_but_with_scheduled_run_in_place(self):
+    @mock.patch('course_discovery.apps.course_metadata.tasks.process_send_course_deadline_email.apply_async')
+    def test_with_course_run_with_end_date_within_range_but_with_reviewed_run_in_place(self, mock_apply_async):
         """
-        Test that the command does not send emails when there is an active course run with Scheduled status
+        Test that the command does not send emails when there is a subsequent Reviewed run.
         """
         self.non_draft_course_run.end = timezone.now() + timedelta(days=7)
         self.non_draft_course_run.save()
-        scheduled_run = CourseRunFactory(
+        reviewed_run = CourseRunFactory(
             course=self.non_draft_course,
             status=CourseRunStatus.Reviewed,
             pacing_type=CourseRunPacing.Self,
@@ -168,7 +169,7 @@ class SendCourseDeadlineEmailsTests(TestCase):
             draft=False,
         )
         SeatFactory(
-            course_run=scheduled_run,
+            course_run=reviewed_run,
             type=SeatTypeFactory.verified(),
             upgrade_deadline=timezone.now() + timedelta(days=100)
         )
@@ -183,9 +184,186 @@ class SendCourseDeadlineEmailsTests(TestCase):
                     LOGGER_PATH,
                     'INFO',
                     f"Course {self.non_draft_course.title} ({self.non_draft_course.key}) "
-                    f"has an active course run with status Scheduled."),
+                    f"has a subsequent active course run."),
                 (LOGGER_PATH, 'INFO', "No courses with deadline within the specified range were found."),
             )
+
+        mock_apply_async.assert_not_called()
+
+    @mock.patch('course_discovery.apps.course_metadata.tasks.process_send_course_deadline_email.apply_async')
+    def test_with_course_run_with_end_date_within_range_but_with_newer_reviewed_run_missing_dates(
+        self, mock_apply_async
+    ):
+        """
+        Test that a reviewed run without schedule dates does not suppress reminders.
+        """
+        self.non_draft_course_run.end = timezone.now() + timedelta(days=7)
+        self.non_draft_course_run.save()
+        CourseRunFactory(
+            course=self.non_draft_course,
+            status=CourseRunStatus.Reviewed,
+            pacing_type=CourseRunPacing.Self,
+            start=None,
+            end=None,
+            draft=False,
+        )
+
+        with LogCapture(LOGGER_PATH) as log_capture:
+            self.run_command()
+
+            log_capture.check(
+                (LOGGER_PATH, 'INFO', "Initializing course deadline email management command."),
+                (LOGGER_PATH, 'INFO', 'Found 1 courses with matching runs.'),
+                (
+                    LOGGER_PATH,
+                    'INFO',
+                    f'Scheduling deadline email for course '
+                    f'{self.non_draft_course.title} ({self.non_draft_course.key}).'
+                ),
+                (
+                    LOGGER_PATH,
+                    'INFO',
+                    f'Deadline email has been scheduled for course '
+                    f'{self.non_draft_course.title} ({self.non_draft_course.key}).'
+                ),
+                (
+                    LOGGER_PATH,
+                    'INFO',
+                    'Scheduled course deadline emails for:\n'
+                    f"- {self.non_draft_course.title} ({self.non_draft_course.uuid})"
+                ),
+            )
+
+        mock_apply_async.assert_called_once()
+
+    @mock.patch('course_discovery.apps.course_metadata.tasks.process_send_course_deadline_email.apply_async')
+    def test_with_course_run_with_end_date_within_range_but_with_published_run_in_place(self, mock_apply_async):
+        """
+        Test that the command does not send emails when a newer published course run exists.
+        """
+        self.non_draft_course_run.end = timezone.now() + timedelta(days=7)
+        self.non_draft_course_run.save()
+        published_run = CourseRunFactory(
+            course=self.non_draft_course,
+            status=CourseRunStatus.Published,
+            pacing_type=CourseRunPacing.Self,
+            start=timezone.now() + timedelta(days=7),
+            end=timezone.now() + timedelta(days=100),
+            draft=False,
+        )
+        SeatFactory(
+            course_run=published_run,
+            type=SeatTypeFactory.verified(),
+            upgrade_deadline=timezone.now() + timedelta(days=100)
+        )
+
+        with LogCapture(LOGGER_PATH) as log_capture:
+            self.run_command()
+
+            log_capture.check(
+                (LOGGER_PATH, 'INFO', "Initializing course deadline email management command."),
+                (LOGGER_PATH, 'INFO', 'Found 1 courses with matching runs.'),
+                (
+                    LOGGER_PATH,
+                    'INFO',
+                    f"Course {self.non_draft_course.title} ({self.non_draft_course.key}) "
+                    f"has no advertised run with end date within the specified range."),
+                (LOGGER_PATH, 'INFO', "No courses with deadline within the specified range were found."),
+            )
+
+        mock_apply_async.assert_not_called()
+
+    @mock.patch('course_discovery.apps.course_metadata.tasks.process_send_course_deadline_email.apply_async')
+    def test_no_advertised_run_uses_latest_run_deterministically(self, mock_apply_async):
+        """
+        Test that the no-advertised-run fallback picks the latest schedule run.
+        """
+        self.non_draft_course_run.status = CourseRunStatus.Unpublished
+        self.non_draft_course_run.end = timezone.now() - timedelta(days=1)
+        self.non_draft_course_run.save()
+
+        CourseRunFactory(
+            course=self.non_draft_course,
+            status=CourseRunStatus.Reviewed,
+            pacing_type=CourseRunPacing.Self,
+            start=None,
+            end=None,
+            draft=False,
+        )
+
+        with LogCapture(LOGGER_PATH) as log_capture:
+            self.run_command()
+
+            log_capture.check(
+                (LOGGER_PATH, 'INFO', "Initializing course deadline email management command."),
+                (LOGGER_PATH, 'INFO', 'Found 1 courses with matching runs.'),
+                (
+                    LOGGER_PATH,
+                    'INFO',
+                    f'Scheduling deadline email for course '
+                    f'{self.non_draft_course.title} ({self.non_draft_course.key}).'
+                ),
+                (
+                    LOGGER_PATH,
+                    'INFO',
+                    f'Deadline email has been scheduled for course '
+                    f'{self.non_draft_course.title} ({self.non_draft_course.key}).'
+                ),
+                (
+                    LOGGER_PATH,
+                    'INFO',
+                    'Scheduled course deadline emails for:\n'
+                    f"- {self.non_draft_course.title} ({self.non_draft_course.uuid})"
+                ),
+            )
+
+        mock_apply_async.assert_called_once()
+
+    @mock.patch('course_discovery.apps.course_metadata.tasks.process_send_course_deadline_email.apply_async')
+    def test_does_not_schedule_duplicate_email_for_same_course_with_multiple_matching_runs(
+        self, mock_apply_async
+    ):
+        """
+        Test that the command only schedules one reminder for a course even if multiple runs match.
+        """
+        self.non_draft_course_run.end = timezone.now() + timedelta(days=30)
+        self.non_draft_course_run.save()
+        CourseRunFactory(
+            course=self.non_draft_course,
+            status=CourseRunStatus.Unpublished,
+            pacing_type=CourseRunPacing.Self,
+            start=timezone.now() - timedelta(days=10),
+            end=timezone.now() + timedelta(days=15),
+            draft=False,
+        )
+
+        with LogCapture(LOGGER_PATH) as log_capture:
+            self.run_command()
+
+            log_capture.check(
+                (LOGGER_PATH, 'INFO', "Initializing course deadline email management command."),
+                (LOGGER_PATH, 'INFO', 'Found 1 courses with matching runs.'),
+                (
+                    LOGGER_PATH,
+                    'INFO',
+                    f'Scheduling deadline email for course '
+                    f'{self.non_draft_course.title} ({self.non_draft_course.key}).'
+                ),
+                (
+                    LOGGER_PATH,
+                    'INFO',
+                    f'Deadline email has been scheduled for course '
+                    f'{self.non_draft_course.title} ({self.non_draft_course.key}).'
+                ),
+                (
+                    LOGGER_PATH,
+                    'INFO',
+                    'Scheduled course deadline emails for:\n'
+                    f"- {self.non_draft_course.title} ({self.non_draft_course.uuid})"
+                ),
+            )
+
+        mock_apply_async.assert_called_once()
 
     def test_with_course_run_just_ended(self):
         """


### PR DESCRIPTION
## Description

This PR updates the `send_course_deadline_emails` management command to prevent deadline reminder emails from being sent when a subsequent active course run already exists for the course.

### Changes
- Added logic to detect subsequent Reviewed/Published course runs before scheduling reminder emails.
- Introduced deterministic course run chronology using schedule dates (`start` with `end` fallback) instead of relying on queryset ordering.
- Added helper methods for determining the latest course run and checking for subsequent active course runs.
- Preserved existing reminder behavior for courses without a subsequent active run.
- Retained existing email scheduling, recipient selection, and reminder cadence.

### Tests
Added/updated unit tests to cover:
- Reminder suppression when a subsequent Reviewed course run exists.
- Reminder suppression when a subsequent Published course run exists.
- Reviewed course runs without schedule dates do not suppress reminders.
- Deterministic latest course run selection.
- Duplicate matching course runs schedule only one reminder.
- Existing reminder and course-ended scenarios continue to work as expected.