### PR TITLE
fix: b2c subscription filter in Course API to return filtered results

### DIFF
--- a/course_discovery/apps/api/filters.py
+++ b/course_discovery/apps/api/filters.py
@@ -87,6 +87,7 @@ class FilterSetMixin:
 class CourseFilter(filters.FilterSet):
     keys = CharListFilter(field_name='key', lookup_expr='in')
     uuids = UUIDListFilter()
+    b2c_subscription_inclusion = filters.BooleanFilter(field_name='b2c_subscription_inclusion')
     course_run_statuses = CharListFilter(method='filter_by_course_run_statuses')
     editors = CharListFilter(field_name='editors__user__pk', lookup_expr='in', distinct=True)
     course_type = filters.CharFilter(method='filter_by_course_type')
@@ -94,7 +95,7 @@ class CourseFilter(filters.FilterSet):
 
     class Meta:
         model = Course
-        fields = ('keys', 'uuids',)
+        fields = ('keys', 'uuids', 'b2c_subscription_inclusion')
 
     def filter_by_course_run_statuses(self, queryset, _, value):
         statuses = set(value.split(','))

--- a/course_discovery/apps/api/v1/tests/test_views/test_courses.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_courses.py
@@ -446,6 +446,50 @@ class CourseViewSetTests(SerializationMixin, ElasticsearchTestMixin, OAuth2Mixin
             response = self.client.get(url)
         self.assertListEqual(response.data['results'], self.serialize_course(courses, many=True))
 
+    def test_list_b2c_subscription_inclusion_filter(self):
+        """ Verify the endpoint filters courses by b2c_subscription_inclusion. """
+        self.course.b2c_subscription_inclusion = False
+        self.course.save()
+
+        b2c_course = CourseFactory(
+            partner=self.partner,
+            b2c_subscription_inclusion=True,
+            key='edX+B2C101',
+        )
+        b2c_course.authoring_organizations.add(self.org)
+
+        url = reverse('api:v1:course-list') + '?b2c_subscription_inclusion=true'
+        response = self.client.get(url)
+
+        assert response.status_code == 200
+        result_keys = {course['key'] for course in response.data['results']}
+
+        assert b2c_course.key in result_keys
+        assert self.course.key not in result_keys
+        assert all(course['b2c_subscription_inclusion'] for course in response.data['results'])
+
+    def test_list_b2c_subscription_inclusion_filter_false(self):
+        """ Verify the endpoint filters courses by b2c_subscription_inclusion=false. """
+        self.course.b2c_subscription_inclusion = False
+        self.course.save()
+
+        b2c_course = CourseFactory(
+            partner=self.partner,
+            b2c_subscription_inclusion=True,
+            key='edX+B2C101',
+        )
+        b2c_course.authoring_organizations.add(self.org)
+
+        url = reverse('api:v1:course-list') + '?b2c_subscription_inclusion=false'
+        response = self.client.get(url)
+
+        assert response.status_code == 200
+        result_keys = {course['key'] for course in response.data['results']}
+
+        assert self.course.key in result_keys
+        assert b2c_course.key not in result_keys
+        assert all(course['b2c_subscription_inclusion'] is False for course in response.data['results'])
+
     def test_list_exclude_utm(self):
         """ Verify the endpoint returns marketing URLs without UTM parameters. """
         url = reverse('api:v1:course-list') + '?exclude_utm=1'


### PR DESCRIPTION
JIRA Ticket - https://2u-internal.atlassian.net/browse/SUBS-871

Adds support for filtering the Courses list API endpoint by the b2c_subscription_inclusion boolean query parameter, so consumers can request only B2C-eligible (or non-eligible) courses and receive correctly filtered results.

Changes:

Adds b2c_subscription_inclusion as a BooleanFilter in the CourseFilter filterset.
Registers b2c_subscription_inclusion in the filterset’s allowed fields.
Adds an API view test to validate filtering behavior for b2c_subscription_inclusion=true or b2c_subscription_inclusion=false.
