### PR TITLE
fix(program-api): B2C Subscription filter to return filtered results

### DIFF
--- a/course_discovery/apps/api/filters.py
+++ b/course_discovery/apps/api/filters.py
@@ -162,11 +162,12 @@ class ProgramFilter(FilterSetMixin, filters.FilterSet):
     type = filters.CharFilter(field_name='type__translations__name_t', lookup_expr='iexact')
     types = CharListFilter(field_name='type__slug', lookup_expr='in')
     uuids = UUIDListFilter()
+    b2c_subscription_inclusion = filters.BooleanFilter(field_name='b2c_subscription_inclusion')
     timestamp = filters.DateTimeFilter(field_name='data_modified_timestamp', lookup_expr='gte')
 
     class Meta:
         model = Program
-        fields = ('hidden', 'marketable', 'marketing_slug', 'status', 'type', 'types',)
+        fields = ('hidden', 'marketable', 'marketing_slug', 'status', 'type', 'types', 'b2c_subscription_inclusion')
 
 
 class ProgramTypeFilter(filters.FilterSet):

--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -2088,7 +2088,7 @@ class MinimalProgramSerializer(TaggitSerializer, FlexFieldsSerializerMixin, Base
             'organization_logo_override_url', 'primary_subject_override', 'level_type_override', 'language_override',
             'labels', 'taxi_form', 'program_duration_override', 'data_modified_timestamp',
             'excluded_from_search', 'excluded_from_seo', 'subscription', 'has_ofac_restrictions', 'ofac_comment',
-            'course_run_statuses',
+            'course_run_statuses', 'b2c_subscription_inclusion',
         )
         read_only_fields = (
             'uuid', 'marketing_url', 'banner_image', 'data_modified_timestamp', 'has_ofac_restrictions', 'ofac_comment'

--- a/course_discovery/apps/api/tests/test_serializers.py
+++ b/course_discovery/apps/api/tests/test_serializers.py
@@ -1181,6 +1181,7 @@ class MinimalProgramSerializerTests(TestCase):
             'excluded_from_search': program.excluded_from_search,
             'has_ofac_restrictions': program.has_ofac_restrictions,
             'ofac_comment': program.ofac_comment,
+            'b2c_subscription_inclusion': program.b2c_subscription_inclusion,
             'subscription_eligible': None,
             'subscription_prices': [],
             'course_run_statuses': program.course_run_statuses,

--- a/course_discovery/apps/api/v1/tests/test_views/test_programs.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_programs.py
@@ -293,6 +293,46 @@ class TestProgramViewSet(SerializationMixin):
 
         self.assert_list_results(url, expected, 18)
 
+    def test_filter_by_b2c_subscription_inclusion_true(self):
+        """ Verify that the endpoint filters programs to B2C-enabled programs. """
+        non_b2c_program = self.create_program()
+        non_b2c_program.b2c_subscription_inclusion = False
+        non_b2c_program.save()
+
+        b2c_program = self.create_program()
+        b2c_program.b2c_subscription_inclusion = True
+        b2c_program.save()
+
+        url = self.list_path + '?b2c_subscription_inclusion=true'
+        response = self.client.get(url)
+
+        assert response.status_code == 200
+        result_uuids = {program['uuid'] for program in response.data['results']}
+
+        assert str(b2c_program.uuid) in result_uuids
+        assert str(non_b2c_program.uuid) not in result_uuids
+        assert all(program['b2c_subscription_inclusion'] for program in response.data['results'])
+
+    def test_filter_by_b2c_subscription_inclusion_false(self):
+        """ Verify that the endpoint filters programs to non-B2C programs. """
+        non_b2c_program = self.create_program()
+        non_b2c_program.b2c_subscription_inclusion = False
+        non_b2c_program.save()
+
+        b2c_program = self.create_program()
+        b2c_program.b2c_subscription_inclusion = True
+        b2c_program.save()
+
+        url = self.list_path + '?b2c_subscription_inclusion=false'
+        response = self.client.get(url)
+
+        assert response.status_code == 200
+        result_uuids = {program['uuid'] for program in response.data['results']}
+
+        assert str(non_b2c_program.uuid) in result_uuids
+        assert str(b2c_program.uuid) not in result_uuids
+        assert all(program['b2c_subscription_inclusion'] is False for program in response.data['results'])
+
     def test_filter_by_timestamp(self):
         """
         Verify that the endpoint filters programs based on modified timestamp.


### PR DESCRIPTION
JIRA Ticket - https://2u-internal.atlassian.net/browse/SUBS-864

Adds support for filtering the Programs list API endpoint by the b2c_subscription_inclusion boolean query parameter, so consumers can request only B2C-eligible (or non-eligible) programs and receive correctly filtered results.
