### PR TITLE
fix: validate missing identifiers in bulk partial update (SUBS-942)

### DIFF
--- a/course_discovery/apps/course_metadata/data_loaders/course_loader.py
+++ b/course_discovery/apps/course_metadata/data_loaders/course_loader.py
@@ -490,8 +490,10 @@ class CourseLoader(AbstractDataLoader, DataLoaderMixin):
         """
         for row in self.reader:
             row = self.transform_dict_keys(row)
-            course_key = row.get('course_key', '')
-            course_run_key = row.get('course_run_key', '')
+            course_key = row.get('course_key', '').strip()
+            course_run_key = row.get('course_run_key', '').strip()
+            row['course_key'] = course_key
+            row['course_run_key'] = course_run_key
             logger.info(f'Starting partial update flow for course: {course_key} and course_run: {course_run_key}')
 
             # Partial updates must identify a target by either course_key or course_run_key.

--- a/course_discovery/apps/course_metadata/data_loaders/course_loader.py
+++ b/course_discovery/apps/course_metadata/data_loaders/course_loader.py
@@ -490,8 +490,8 @@ class CourseLoader(AbstractDataLoader, DataLoaderMixin):
         """
         for row in self.reader:
             row = self.transform_dict_keys(row)
-            course_key = row.get('course_key', '').strip()
-            course_run_key = row.get('course_run_key', '').strip()
+            course_key = (row.get('course_key') or '').strip()
+            course_run_key = (row.get('course_run_key') or '').strip()
             row['course_key'] = course_key
             row['course_run_key'] = course_run_key
             logger.info(f'Starting partial update flow for course: {course_key} and course_run: {course_run_key}')

--- a/course_discovery/apps/course_metadata/data_loaders/course_loader.py
+++ b/course_discovery/apps/course_metadata/data_loaders/course_loader.py
@@ -494,6 +494,14 @@ class CourseLoader(AbstractDataLoader, DataLoaderMixin):
             course_run_key = row.get('course_run_key', '')
             logger.info(f'Starting partial update flow for course: {course_key} and course_run: {course_run_key}')
 
+            # Partial updates must identify a target by either course_key or course_run_key.
+            if not course_key and not course_run_key:
+                self.log_ingestion_error(
+                    CSVIngestionErrors.MISSING_REQUIRED_DATA,
+                    'Missing required identifiers for partial update: provide course_key or course_run_key.'
+                )
+                continue
+
             try:
                 course, course_run = self.extract_course_and_course_run(row)
             except CourseRun.DoesNotExist:

--- a/course_discovery/apps/course_metadata/data_loaders/tests/test_course_loader.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/test_course_loader.py
@@ -622,6 +622,42 @@ class TestCourseLoader(CSVLoaderMixin, OAuth2Mixin, APITestCase):
             in loader.error_logs["MISSING_REQUIRED_DATA"][0]
         )
 
+    def test_course_loader_partial_updates_truncated_row_does_not_crash(self, mock_jwt_decode_handler):  # pylint: disable=unused-argument
+        """
+        Verify partial updates handle truncated CSV rows where DictReader returns None for missing trailing fields.
+        """
+        self.create_new_course()
+
+        with NamedTemporaryFile() as csv:
+            csv.write(
+                b"Course Key,Course Run Key,Long Description\n"
+                b"edx+csv-123\n"
+            )
+            csv.seek(0)
+
+            with LogCapture() as log_capture:
+                with mock.patch.object(
+                        CourseLoader,
+                        'call_course_api',
+                        self.mock_call_course_api
+                ):
+                    loader = CourseLoader(
+                        self.partner, csv_path=csv.name,
+                        product_source=self.source.slug,
+                        task_type=BulkOperationType.PartialUpdate
+                    )
+                    loader.ingest()
+                    log_capture.check_present(
+                        (
+                            LOGGER_PATH,
+                            'INFO',
+                            f"Initiating Course Loader for {BulkOperationType.PartialUpdate}"
+                        )
+                    )
+
+        assert loader.ingestion_summary["failure_count"] == 0
+        assert loader.ingestion_summary["success_count"] == 1
+
     @data(("true", True), ("false", False))
     @unpack
     def test_course_loader_partial_updates_b2c_subscription_inclusion(

--- a/course_discovery/apps/course_metadata/data_loaders/tests/test_course_loader.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/test_course_loader.py
@@ -592,15 +592,24 @@ class TestCourseLoader(CSVLoaderMixin, OAuth2Mixin, APITestCase):
         assert course_run.min_effort is None
         assert loader.ingestion_summary["success_count"] == 1
 
-    def test_course_loader_partial_updates_missing_both_identifiers(self, mock_jwt_decode_handler):  # pylint: disable=unused-argument
+    @data(
+        ("", ""),
+        ("   ", "   "),
+        ("", "   "),
+        ("   ", ""),
+    )
+    @unpack
+    def test_course_loader_partial_updates_missing_both_identifiers(
+        self, course_key, course_run_key, mock_jwt_decode_handler  # pylint: disable=unused-argument
+    ):
         """
-        Verify partial updates fail fast when both course_key and course_run_key are missing.
+        Verify partial updates fail fast when both course_key and course_run_key are missing or whitespace-only.
         """
         self.create_new_course()
 
         csv_data = {
-            "Course Key": "",
-            "Course Run Key": "",
+            "Course Key": course_key,
+            "Course Run Key": course_run_key,
             "Long Description": "Should fail due to missing identifiers",
         }
 

--- a/course_discovery/apps/course_metadata/data_loaders/tests/test_course_loader.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/test_course_loader.py
@@ -592,6 +592,27 @@ class TestCourseLoader(CSVLoaderMixin, OAuth2Mixin, APITestCase):
         assert course_run.min_effort is None
         assert loader.ingestion_summary["success_count"] == 1
 
+    def test_course_loader_partial_updates_missing_both_identifiers(self, mock_jwt_decode_handler):  # pylint: disable=unused-argument
+        """
+        Verify partial updates fail fast when both course_key and course_run_key are missing.
+        """
+        self.create_new_course()
+
+        csv_data = {
+            "Course Key": "",
+            "Course Run Key": "",
+            "Long Description": "Should fail due to missing identifiers",
+        }
+
+        loader, _ = self.perform_partial_updates(csv_data)
+
+        assert loader.ingestion_summary["failure_count"] == 1
+        assert loader.ingestion_summary["success_count"] == 0
+        assert (
+            "Missing required identifiers for partial update: provide course_key or course_run_key."
+            in loader.error_logs["MISSING_REQUIRED_DATA"][0]
+        )
+
     @data(("true", True), ("false", False))
     @unpack
     def test_course_loader_partial_updates_b2c_subscription_inclusion(


### PR DESCRIPTION
This pr is regarding the [ticket](https://2u-internal.atlassian.net/browse/SUBS-942)

Changes:

Added an explicit early-exit guard at the top of _ingest_partial_update in course_loader.py:

Testing:

1)verified the functionality by giving empty course and course run key ,Asserts failure_count == 1, success_count == 0, and the correct MISSING_REQUIRED_DATA error message is present .
2)added a test case in test_course_loader.py